### PR TITLE
hotfix: added sprint feature for backend and frontend

### DIFF
--- a/forgetask-frontend/app/components/kanban/KanbanApp.tsx
+++ b/forgetask-frontend/app/components/kanban/KanbanApp.tsx
@@ -17,11 +17,15 @@ import { useTaskWebSocket, type TaskEventMessage } from '@/app/hooks/useTaskWebS
 import { useTaskStore } from '@/app/store/taskStore'
 import taskService from '@/app/services/taskService'
 import type { TaskAssigneeOption } from '@/app/types/task'
+import sprintService from '@/app/services/sprintService'
+import type { SprintOption } from '@/app/types/sprint'
 
 export function KanbanApp() {
   // Obtener acciones del store global de tareas
-  const { setTasks, updateTask, addTask, removeTask } = useTaskStore()
+  const { tasks, setTasks, updateTask, addTask, removeTask } = useTaskStore()
   const [assigneeOptions, setAssigneeOptions] = useState<TaskAssigneeOption[]>([])
+  const [projectId, setProjectId] = useState<number | null>(null)
+  const [sprintOptions, setSprintOptions] = useState<SprintOption[]>([])
 
   /**
    * Callback que se ejecuta cuando llega un evento del servidor via WebSocket
@@ -86,6 +90,15 @@ export function KanbanApp() {
         console.log('✅ Tareas cargadas:', tasks.length)
         setTasks(tasks)
         setAssigneeOptions(users)
+
+        const resolvedProjectId = users.length > 0 ? users[0].idProject : null
+        setProjectId(resolvedProjectId)
+        if (resolvedProjectId) {
+          const sprints = await sprintService.listSprints(resolvedProjectId)
+          setSprintOptions(sprints)
+        } else {
+          setSprintOptions([])
+        }
       } catch (error) {
         console.error('❌ Error cargando tareas iniciales:', error)
       }
@@ -93,6 +106,23 @@ export function KanbanApp() {
 
     loadInitialTasks()
   }, [setTasks])
+
+  const handleSprintSaved = useCallback((savedSprint: SprintOption) => {
+    setSprintOptions((current) => {
+      const next = current.some((sprint) => sprint.idSprint === savedSprint.idSprint)
+        ? current.map((sprint) => (sprint.idSprint === savedSprint.idSprint ? savedSprint : sprint))
+        : [...current, savedSprint]
+
+      return next.sort((a, b) => a.sprintNumber - b.sprintNumber)
+    })
+  }, [])
+  
+  const handleSprintDeleted = useCallback((sprintId: number) => {
+    setSprintOptions((current) => current.filter((sprint) => sprint.idSprint !== sprintId))
+    setTasks(
+      tasks.map((task) => (task.sprintId === sprintId ? { ...task, sprintId: undefined } : task))
+    )
+  }, [setTasks, tasks])
 
   return (
     <DndProvider backend={HTML5Backend}>
@@ -103,6 +133,10 @@ export function KanbanApp() {
           onSendCreate={sendCreateTask}
           onSendDelete={sendDeleteTask}
           assigneeOptions={assigneeOptions}
+          projectId={projectId}
+          sprintOptions={sprintOptions}
+          onSprintSaved={handleSprintSaved}
+          onSprintDeleted={handleSprintDeleted}
         />
       </div>
     </DndProvider>

--- a/forgetask-frontend/app/components/kanban/add-sprint-dialog.tsx
+++ b/forgetask-frontend/app/components/kanban/add-sprint-dialog.tsx
@@ -1,0 +1,247 @@
+'use client'
+
+import type * as React from 'react'
+import { useState } from 'react'
+import { Calendar } from 'lucide-react'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+import { DatePickerInput } from '../ui/date-picker-input'
+import { Label } from '../ui/label'
+import { Textarea } from '../ui/textarea'
+import sprintService from '@/app/services/sprintService'
+import type { SprintOption } from '@/app/types/sprint'
+
+interface AddSprintDialogProps {
+  projectId: number | null
+  sprintOptions: SprintOption[]
+  onSprintSaved: (sprint: SprintOption) => void
+  onSprintDeleted: (sprintId: number) => void
+}
+
+export function AddSprintDialog({ projectId, sprintOptions, onSprintSaved, onSprintDeleted }: AddSprintDialogProps) {
+  const [open, setOpen] = useState(false)
+  const [selectedSprintId, setSelectedSprintId] = useState('')
+  const [sprintNumber, setSprintNumber] = useState('')
+  const [goal, setGoal] = useState('')
+  const [startDate, setStartDate] = useState('')
+  const [endDate, setEndDate] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  const parseSprintNumberFromTitle = (value?: string) => {
+    if (!value) {
+      return ''
+    }
+    const match = value.match(/sprint\s*#\s*(\d+)/i)
+    return match ? match[1] : ''
+  }
+
+  const formatSprintLabel = (sprint: SprintOption) => {
+    const start = sprint.startDate || '-'
+    const end = sprint.endDate || '-'
+    return `${sprint.title} (${start} - ${end})`
+  }
+
+  const openDialog = () => {
+    setSelectedSprintId('')
+    setSprintNumber('')
+    setGoal('')
+    setStartDate('')
+    setEndDate('')
+    setOpen(true)
+  }
+
+  const isEditMode = Boolean(selectedSprintId)
+
+  const handleDelete = async () => {
+    if (!projectId || !selectedSprintId) {
+      return
+    }
+
+    const sprintIdNumber = Number(selectedSprintId)
+    if (!Number.isFinite(sprintIdNumber)) {
+      return
+    }
+
+    const ok = window.confirm('Delete this sprint? This cannot be undone.')
+    if (!ok) {
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      await sprintService.deleteSprint(sprintIdNumber)
+      onSprintDeleted(sprintIdNumber)
+      setOpen(false)
+    } catch (error) {
+      console.error('Error deleting sprint:', error)
+      window.alert('No se pudo borrar el sprint. Revisa los logs del backend para más detalle.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!projectId) {
+      return
+    }
+
+    const parsedSprintNumber = sprintNumber.trim() === '' ? NaN : Number(sprintNumber)
+    if (!Number.isFinite(parsedSprintNumber) || parsedSprintNumber <= 0) {
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const request = {
+        projectId,
+        sprintNumber: parsedSprintNumber,
+        goal: goal || undefined,
+        startDate: startDate || undefined,
+        endDate: endDate || undefined,
+      }
+
+      const saved = isEditMode
+        ? await sprintService.updateSprint(Number(selectedSprintId), request)
+        : await sprintService.createSprint(request)
+
+      onSprintSaved(saved)
+      setOpen(false)
+    } catch (error) {
+      console.error('Error saving sprint:', error)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <>
+      <Button
+        className="gap-2 cursor-pointer"
+        variant="outline"
+        onClick={openDialog}
+        disabled={!projectId}
+        title={!projectId ? 'Project not resolved yet' : 'Create a new sprint'}
+      >
+        <Calendar className="w-4 h-4" />
+        Check Sprint
+      </Button>
+      {open && (
+        <div className="fixed inset-0 z-50 grid place-items-center bg-black/70 backdrop-blur-[2px] p-4">
+          <div className="w-full max-w-[680px] max-h-[90vh] overflow-y-auto rounded-xl border border-[#923811]/70 bg-[#140c09] p-6 shadow-[0_0_28px_rgba(231,107,54,0.28)]">
+            <form onSubmit={handleSubmit}>
+              <div className="flex items-start justify-between gap-4 pb-4 border-b border-[#923811]/40">
+                <div>
+                  <h2 className="text-xl font-semibold neon-orange">Create New Sprint</h2>
+                  <p className="text-sm text-[#ffd5c2]/85 mt-1">
+                    Add a new sprint to your project.
+                  </p>
+                </div>
+                <Button type="button" variant="outline" onClick={() => setOpen(false)} className="cursor-pointer">
+                  Close
+                </Button>
+              </div>
+
+              <div className="grid gap-4 py-5">
+                <div className="grid gap-2 rounded-lg border border-[#923811]/50 bg-[#1a100d] p-3">
+                  <Label htmlFor="sprint-select">Sprint (optional)</Label>
+                  <select
+                    id="sprint-select"
+                    value={selectedSprintId}
+                    onChange={(e) => {
+                      const value = e.target.value
+                      setSelectedSprintId(value)
+
+                      if (!value) {
+                        setSprintNumber('')
+                        setGoal('')
+                        setStartDate('')
+                        setEndDate('')
+                        return
+                      }
+
+                      const sprint = sprintOptions.find((option) => String(option.idSprint) === value)
+                      if (sprint) {
+                        setSprintNumber(parseSprintNumberFromTitle(sprint.title))
+                        setGoal(sprint.goal || '')
+                        setStartDate(sprint.startDate || '')
+                        setEndDate(sprint.endDate || '')
+                      }
+                    }}
+                    title="Select sprint to edit"
+                    className="border-input bg-input-background rounded-md border px-3 py-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] cursor-pointer"
+                    disabled={sprintOptions.length === 0}
+                  >
+                    <option value="">Create new sprint</option>
+                    {sprintOptions.map((sprint) => (
+                      <option key={sprint.idSprint} value={String(sprint.idSprint)}>
+                        {formatSprintLabel(sprint)}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="grid gap-2 rounded-lg border border-[#923811]/50 bg-[#1a100d] p-3">
+                  <Label htmlFor="sprint-number">Sprint Number *</Label>
+                  <Input
+                    id="sprint-number"
+                    value={sprintNumber}
+                    onChange={(e) => setSprintNumber(e.target.value)}
+                    placeholder="1"
+                    inputMode="numeric"
+                    required
+                  />
+                </div>
+
+                <div className="grid gap-2 rounded-lg border border-[#923811]/50 bg-[#1a100d] p-3">
+                  <Label htmlFor="sprint-goal">Goal</Label>
+                  <Textarea
+                    id="sprint-goal"
+                    value={goal}
+                    onChange={(e) => setGoal(e.target.value)}
+                    placeholder="Sprint goal"
+                    rows={3}
+                  />
+                </div>
+
+                <div className="grid gap-2 rounded-lg border border-[#923811]/50 bg-[#1a100d] p-3">
+                  <Label htmlFor="sprint-start">Start Date</Label>
+                  <DatePickerInput id="sprint-start" value={startDate} onChange={setStartDate} />
+                </div>
+
+                <div className="grid gap-2 rounded-lg border border-[#923811]/50 bg-[#1a100d] p-3">
+                  <Label htmlFor="sprint-end">End Date</Label>
+                  <DatePickerInput id="sprint-end" value={endDate} onChange={setEndDate} />
+                </div>
+              </div>
+
+              <div className="flex justify-end gap-2 pt-4 border-t border-[#923811]/40">
+                {isEditMode && (
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    onClick={handleDelete}
+                    className="cursor-pointer"
+                    disabled={!projectId || submitting}
+                  >
+                    Delete Sprint
+                  </Button>
+                )}
+                <Button type="button" variant="outline" onClick={() => setOpen(false)} className="cursor-pointer">
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  className="cursor-pointer neon-orange-bg text-white"
+                  disabled={!projectId || submitting}
+                >
+                  {submitting ? 'Saving...' : isEditMode ? 'Save Changes' : 'Create Sprint'}
+                </Button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/forgetask-frontend/app/components/kanban/add-task-dialog.tsx
+++ b/forgetask-frontend/app/components/kanban/add-task-dialog.tsx
@@ -24,10 +24,12 @@ import { Label } from '../ui/label'
 import { Textarea } from '../ui/textarea'
 import type { Task } from './task-card'
 import type { TaskAssigneeOption } from '@/app/types/task'
+import type { SprintOption } from '@/app/types/sprint'
 
 interface AddTaskDialogProps {
   onAddTask: (task: Omit<Task, 'id'>) => void
   assigneeOptions: TaskAssigneeOption[]
+  sprintOptions: SprintOption[]
 }
 
 /**
@@ -37,7 +39,7 @@ interface AddTaskDialogProps {
  * - onAddTask: Callback que recibe los datos de la tarea creada
  *   (ProjectBoard pasa una función que ejecuta WebSocket.createTask)
  */
-export function AddTaskDialog({ onAddTask, assigneeOptions }: AddTaskDialogProps) {
+export function AddTaskDialog({ onAddTask, assigneeOptions, sprintOptions }: AddTaskDialogProps) {
   // Estado del formulario
   const [open, setOpen] = useState(false)
   const [title, setTitle] = useState('')
@@ -49,9 +51,21 @@ export function AddTaskDialog({ onAddTask, assigneeOptions }: AddTaskDialogProps
   const [estimatedTime, setEstimatedTime] = useState('')
   const [realTime] = useState('0')
   const [assignedTo, setAssignedTo] = useState('')
+  const [sprintId, setSprintId] = useState('')
+
+  const formatSprintLabel = (idSprint: number) => {
+    const sprint = sprintOptions.find((option) => option.idSprint === idSprint)
+    if (!sprint) {
+      return 'Sprint'
+    }
+    const start = sprint.startDate || '-'
+    const end = sprint.endDate || '-'
+    return `${sprint.title} (${start} - ${end})`
+  }
 
   const openDialog = () => {
     setAssignedTo('')
+    setSprintId('')
     setOpen(true)
   }
 
@@ -76,9 +90,13 @@ export function AddTaskDialog({ onAddTask, assigneeOptions }: AddTaskDialogProps
       return
     }
 
+    const resolvedSprintId = sprintId ? Number(sprintId) : undefined
+    const sprintIdValue = Number.isFinite(resolvedSprintId) ? resolvedSprintId : undefined
+
     // Enviar datos de la nueva tarea al callback (ProjectBoard)
     // ProjectBoard tiene WebSocket.createTask que envía esto al backend
     onAddTask({
+      sprintId: sprintIdValue,
       title,
       description: description || undefined,
       status,
@@ -100,6 +118,7 @@ export function AddTaskDialog({ onAddTask, assigneeOptions }: AddTaskDialogProps
     setEstimatedTime("");
     // realTime stays locked to 0 on create dialog.
     setAssignedTo("");
+    setSprintId("")
     setOpen(false);
   };
 
@@ -176,6 +195,25 @@ export function AddTaskDialog({ onAddTask, assigneeOptions }: AddTaskDialogProps
                       <option value="high">High</option>
                     </select>
                   </div>
+                </div>
+
+                <div className="grid gap-2 rounded-lg border border-[#923811]/50 bg-[#1a100d] p-3">
+                  <Label htmlFor="sprintId">Sprint</Label>
+                  <select
+                    id="sprintId"
+                    value={sprintId}
+                    onChange={(e) => setSprintId(e.target.value)}
+                    title="Sprint"
+                    className="border-input bg-input-background rounded-md border px-3 py-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] cursor-pointer"
+                    disabled={sprintOptions.length === 0}
+                  >
+                    <option value="">Select sprint</option>
+                    {sprintOptions.map((sprint) => (
+                      <option key={sprint.idSprint} value={String(sprint.idSprint)}>
+                        {formatSprintLabel(sprint.idSprint)}
+                      </option>
+                    ))}
+                  </select>
                 </div>
                 <div className="grid gap-2 rounded-lg border border-[#923811]/50 bg-[#1a100d] p-3">
                   <Label htmlFor="startDate">Start Date</Label>

--- a/forgetask-frontend/app/components/kanban/project-board.tsx
+++ b/forgetask-frontend/app/components/kanban/project-board.tsx
@@ -28,12 +28,14 @@ import {
 } from 'lucide-react'
 import { TaskCard, type Task } from './task-card'
 import { AddTaskDialog } from './add-task-dialog'
+import { AddSprintDialog } from './add-sprint-dialog'
 import { TaskDetailsDialog } from './task-details-dialog'
 import { MembersDialog } from './members-dialog'
 import { Button } from '../ui/button'
 import { Progress } from '../ui/progress'
 import { useTaskStore } from '@/app/store/taskStore'
 import type { TaskAssigneeOption } from '@/app/types/task'
+import type { SprintOption } from '@/app/types/sprint'
 
 interface ColumnProps {
   title: string
@@ -41,6 +43,7 @@ interface ColumnProps {
   tasks: Task[]
   icon: React.ReactNode
   expectedTasks?: number  // Opcional - si es undefined, no hay límite (como Done)
+  sprintOptions: SprintOption[]
   onDrop: (task: Task, newStatus: Task['status']) => void
   onDeleteTask: (id: string) => void
   onTaskClick: (task: Task) => void
@@ -53,6 +56,7 @@ function Column({
   tasks,
   icon,
   expectedTasks,
+  sprintOptions,
   onDrop,
   onDeleteTask,
   onTaskClick,
@@ -194,6 +198,7 @@ function Column({
             <TaskCard
               key={task.id}
               task={task}
+              sprintOptions={sprintOptions}
               onTaskClick={onTaskClick}
               onDeleteTask={onDeleteTask}
             />
@@ -215,6 +220,10 @@ interface ProjectBoardProps {
   onSendCreate: (taskData: Omit<Task, 'id'>) => void
   onSendDelete: (taskId: string) => void
   assigneeOptions: TaskAssigneeOption[]
+  projectId: number | null
+  sprintOptions: SprintOption[]
+  onSprintSaved: (sprint: SprintOption) => void
+  onSprintDeleted: (sprintId: number) => void
 }
 
 /**
@@ -226,6 +235,10 @@ export function ProjectBoard({
   onSendCreate,
   onSendDelete,
   assigneeOptions,
+  projectId,
+  sprintOptions,
+  onSprintSaved,
+  onSprintDeleted,
 }: ProjectBoardProps) {
   // Obtener tareas del store global (se actualiza automáticamente con eventos WebSocket)
   const tasks = useTaskStore((state) => state.tasks)
@@ -403,7 +416,13 @@ export function ProjectBoard({
               <FileText className="w-4 h-4 mr-2" />
               Generate Report
             </Button>
-            <AddTaskDialog onAddTask={handleAddTask} assigneeOptions={assigneeOptions} />
+            <AddSprintDialog
+              projectId={projectId}
+              sprintOptions={sprintOptions}
+              onSprintSaved={onSprintSaved}
+              onSprintDeleted={onSprintDeleted}
+            />
+            <AddTaskDialog onAddTask={handleAddTask} assigneeOptions={assigneeOptions} sprintOptions={sprintOptions} />
           </div>
         </div>
       </header>
@@ -418,6 +437,7 @@ export function ProjectBoard({
               status="backlog"
               tasks={backlogTasks}
               icon={<Circle className="w-5 h-5 text-muted-foreground" />}
+              sprintOptions={sprintOptions}
               onDrop={handleDrop}
               onDeleteTask={handleDeleteTask}
               onTaskClick={handleTaskClick}
@@ -433,6 +453,7 @@ export function ProjectBoard({
               status="ready"
               tasks={readyTasks}
               icon={<Layers className="w-5 h-5 text-secondary" />}
+              sprintOptions={sprintOptions}
               onDrop={handleDrop}
               onDeleteTask={handleDeleteTask}
               onTaskClick={handleTaskClick}
@@ -448,6 +469,7 @@ export function ProjectBoard({
               status="in-progress"
               tasks={inProgressTasks}
               icon={<CircleDot className="w-5 h-5 text-blue-400" />}
+              sprintOptions={sprintOptions}
               onDrop={handleDrop}
               onDeleteTask={handleDeleteTask}
               onTaskClick={handleTaskClick}
@@ -463,6 +485,7 @@ export function ProjectBoard({
               status="review"
               tasks={reviewTasks}
               icon={<Eye className="w-5 h-5 text-destructive" />}
+              sprintOptions={sprintOptions}
               onDrop={handleDrop}
               onDeleteTask={handleDeleteTask}
               onTaskClick={handleTaskClick}
@@ -478,6 +501,7 @@ export function ProjectBoard({
               status="done"
               tasks={doneTasks}
               icon={<CheckCircle2 className="w-5 h-5 text-green-400" />}
+              sprintOptions={sprintOptions}
               onDrop={handleDrop}
               onDeleteTask={handleDeleteTask}
               onTaskClick={handleTaskClick}
@@ -495,6 +519,7 @@ export function ProjectBoard({
           onOpenChange={setDetailsDialogOpen}
           onUpdateTask={handleUpdateTask}
           assigneeOptions={assigneeOptions}
+          sprintOptions={sprintOptions}
         />
       )}
 

--- a/forgetask-frontend/app/components/kanban/task-card.tsx
+++ b/forgetask-frontend/app/components/kanban/task-card.tsx
@@ -9,15 +9,17 @@
  */
 
 import { useDrag } from 'react-dnd'
-import { GripVertical, Trash2, Calendar, Clock, User } from 'lucide-react'
+import { GripVertical, Trash2, Calendar, Clock, User, Layers } from 'lucide-react'
 import { Button } from '../ui/button'
 import { Badge } from '../ui/badge'
 import { memo } from 'react'
 import type { Task } from '@/app/types/task'
+import type { SprintOption } from '@/app/types/sprint'
 export type { Task }
 
 interface TaskCardProps {
   task: Task
+  sprintOptions: SprintOption[]
   onTaskClick: (task: Task) => void
   onDeleteTask: (id: string) => void
 }
@@ -37,7 +39,7 @@ interface TaskCardProps {
  * - Muestra fechas, horas estimadas/reales, y usuario asignado
  * - Botón delete que aparece al pasar el mouse
  */
-export function TaskCard({ task, onTaskClick, onDeleteTask }: TaskCardProps) {
+export function TaskCard({ task, sprintOptions, onTaskClick, onDeleteTask }: TaskCardProps) {
   // useDrag: Hook de react-dnd que hace esta tarjeta arrastrable
   // Cuando se arrastra, se envía el objeto { task } al drop handler en Column
   const [{ isDragging }, drag] = useDrag(() => ({
@@ -81,6 +83,10 @@ export function TaskCard({ task, onTaskClick, onDeleteTask }: TaskCardProps) {
   const hasAnyDate = Boolean(task.startDate || task.endDate)
   const dateRangeLabel = `${task.startDate ? formatTaskDate(task.startDate) : '-'} - ${task.endDate ? formatTaskDate(task.endDate) : '-'}`
 
+  const sprint = task.sprintId ? sprintOptions.find((option) => option.idSprint === task.sprintId) : undefined
+  const sprintLabel = sprint?.title
+  const sprintRangeTitle = sprint ? `${sprint.title} (${sprint.startDate || '-'} - ${sprint.endDate || '-'})` : undefined
+
   return (
     <div
       ref={(node) => {
@@ -105,6 +111,14 @@ export function TaskCard({ task, onTaskClick, onDeleteTask }: TaskCardProps) {
             <Badge variant="outline" className={priorityColors[task.priority]}>
               {task.priority}
             </Badge>
+          )}
+
+          {/* Sprint */}
+          {task.sprintId !== undefined && task.sprintId !== null && sprintLabel && (
+            <div className="flex items-center gap-1 text-xs text-[#d4a791]" title={sprintRangeTitle}>
+              <Layers className="w-3 h-3 flex-shrink-0" />
+              <span className="truncate">{sprintLabel}</span>
+            </div>
           )}
 
           {/* Date Range */}

--- a/forgetask-frontend/app/components/kanban/task-details-dialog.tsx
+++ b/forgetask-frontend/app/components/kanban/task-details-dialog.tsx
@@ -25,6 +25,7 @@ import { Label } from '../ui/label'
 import { Textarea } from '../ui/textarea'
 import type { Task } from './task-card'
 import type { TaskAssigneeOption } from '@/app/types/task'
+import type { SprintOption } from '@/app/types/sprint'
 
 interface TaskDetailsDialogProps {
   task: Task | null
@@ -32,6 +33,7 @@ interface TaskDetailsDialogProps {
   onOpenChange: (open: boolean) => void
   onUpdateTask: (task: Task) => void
   assigneeOptions: TaskAssigneeOption[]
+  sprintOptions: SprintOption[]
 }
 
 /**
@@ -50,6 +52,7 @@ export function TaskDetailsDialog({
   onOpenChange,
   onUpdateTask,
   assigneeOptions,
+  sprintOptions,
 }: TaskDetailsDialogProps) {
   // Estado del formulario
   const [title, setTitle] = useState('')
@@ -61,7 +64,18 @@ export function TaskDetailsDialog({
   const [estimatedTime, setEstimatedTime] = useState('')
   const [realTime, setRealTime] = useState('')
   const [assignedTo, setAssignedTo] = useState('')
+  const [sprintId, setSprintId] = useState('')
   const [dateError, setDateError] = useState('')
+
+  const formatSprintLabel = (idSprint: number) => {
+    const sprint = sprintOptions.find((option) => option.idSprint === idSprint)
+    if (!sprint) {
+      return 'Sprint'
+    }
+    const start = sprint.startDate || '-'
+    const end = sprint.endDate || '-'
+    return `${sprint.title} (${start} - ${end})`
+  }
 
   const normalizeDateForInput = (value?: string) => {
     if (!value) {
@@ -102,6 +116,12 @@ export function TaskDetailsDialog({
       })
 
       setAssignedTo(matchedOption?.username || usernameFromTask || '')
+
+      if (task.sprintId !== undefined && task.sprintId !== null) {
+        setSprintId(String(task.sprintId))
+      } else {
+        setSprintId('')
+      }
     }
   }, [task, assigneeOptions])
 
@@ -132,8 +152,12 @@ export function TaskDetailsDialog({
     const estimatedTimeValue = Number.isFinite(parsedEstimatedTime) ? parsedEstimatedTime : undefined
     const realTimeValue = Number.isFinite(parsedRealTime) ? parsedRealTime : undefined
 
+    const resolvedSprintId = sprintId ? Number(sprintId) : undefined
+    const sprintIdValue = Number.isFinite(resolvedSprintId) ? resolvedSprintId : undefined
+
     onUpdateTask({
       ...task,
+      sprintId: sprintIdValue,
       title,
       description: description || undefined,
       status,
@@ -291,6 +315,25 @@ export function TaskDetailsDialog({
                     </option>
                   ))
                 )}
+              </select>
+            </div>
+
+            <div className="grid gap-2 rounded-lg border border-[#923811]/50 bg-[#1a100d] p-3">
+              <Label htmlFor="edit-sprint">Sprint</Label>
+              <select
+                id="edit-sprint"
+                value={sprintId}
+                onChange={(e) => setSprintId(e.target.value)}
+                title="Sprint"
+                className="border-input bg-input-background rounded-md border px-3 py-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] cursor-pointer"
+                disabled={sprintOptions.length === 0}
+              >
+                <option value="">Select sprint</option>
+                {sprintOptions.map((sprint) => (
+                  <option key={sprint.idSprint} value={String(sprint.idSprint)}>
+                    {formatSprintLabel(sprint.idSprint)}
+                  </option>
+                ))}
               </select>
             </div>
           </div>

--- a/forgetask-frontend/app/services/sprintService.ts
+++ b/forgetask-frontend/app/services/sprintService.ts
@@ -1,0 +1,69 @@
+import type { SprintCreateRequest, SprintOption } from "@/app/types/sprint";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+
+class SprintService {
+  async listSprints(projectId?: number): Promise<SprintOption[]> {
+    const query = projectId !== undefined ? `?projectId=${projectId}` : "";
+    const response = await fetch(`${API_BASE_URL}/api/sprints${query}`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch sprints: ${response.statusText}`);
+    }
+
+    return await response.json();
+  }
+
+  async createSprint(request: SprintCreateRequest): Promise<SprintOption> {
+    const response = await fetch(`${API_BASE_URL}/api/sprints`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to create sprint: ${response.statusText}`);
+    }
+
+    return await response.json();
+  }
+
+  async updateSprint(sprintId: number, request: SprintCreateRequest): Promise<SprintOption> {
+    const response = await fetch(`${API_BASE_URL}/api/sprints/${sprintId}`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to update sprint: ${response.statusText}`);
+    }
+
+    return await response.json();
+  }
+
+  async deleteSprint(sprintId: number): Promise<void> {
+    const response = await fetch(`${API_BASE_URL}/api/sprints/${sprintId}`, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to delete sprint: ${response.status} ${response.statusText}`);
+    }
+  }
+}
+
+const sprintService = new SprintService();
+export default sprintService;

--- a/forgetask-frontend/app/store/taskStore.ts
+++ b/forgetask-frontend/app/store/taskStore.ts
@@ -26,6 +26,7 @@ import { create } from 'zustand'
 // Interfaz de Task que debe coincidir con TaskDTO del backend
 interface Task {
   id: string
+  sprintId?: number
   title: string
   description?: string
   status: 'backlog' | 'ready' | 'in-progress' | 'review' | 'done'

--- a/forgetask-frontend/app/types/sprint.ts
+++ b/forgetask-frontend/app/types/sprint.ts
@@ -1,0 +1,17 @@
+export interface SprintOption {
+  idSprint: number;
+  idProject: number;
+  sprintNumber: number;
+  title: string;
+  goal?: string;
+  startDate?: string;
+  endDate?: string;
+}
+
+export interface SprintCreateRequest {
+  projectId?: number;
+  sprintNumber: number;
+  goal?: string;
+  startDate?: string;
+  endDate?: string;
+}

--- a/forgetask-frontend/app/types/task.ts
+++ b/forgetask-frontend/app/types/task.ts
@@ -1,5 +1,6 @@
 export interface Task {
   id: string;
+  sprintId?: number;
   title: string;
   description?: string;
   status: "backlog" | "ready" | "in-progress" | "review" | "done";

--- a/forgetask/src/main/java/com/cloudforge/api/forgetask/controller/SprintController.java
+++ b/forgetask/src/main/java/com/cloudforge/api/forgetask/controller/SprintController.java
@@ -1,0 +1,307 @@
+package com.cloudforge.api.forgetask.controller;
+
+import com.cloudforge.api.forgetask.dto.SprintOptionDTO;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/sprints")
+public class SprintController {
+
+    private static final String LIST_SPRINTS_SQL = """
+            SELECT s.ID_SPRINT,
+                   s.ID_PROJECT,
+                   COALESCE(
+                       CASE
+                           WHEN REGEXP_LIKE(s.TITLE, 'Sprint\\s*#\\s*[0-9]+', 'i')
+                               THEN TO_NUMBER(REGEXP_SUBSTR(s.TITLE, 'Sprint\\s*#\\s*([0-9]+)', 1, 1, NULL, 1))
+                           ELSE NULL
+                       END,
+                       ROW_NUMBER() OVER (PARTITION BY s.ID_PROJECT ORDER BY s.START_DATE NULLS LAST, s.ID_SPRINT)
+                   ) AS SPRINT_NUMBER,
+                   s.TITLE,
+                   s.GOAL,
+                   TO_CHAR(s.START_DATE, 'YYYY-MM-DD') AS START_DATE_TEXT,
+                   TO_CHAR(s.END_DATE, 'YYYY-MM-DD') AS END_DATE_TEXT
+            FROM SPRINT s
+            WHERE s.ID_PROJECT = ?
+            ORDER BY SPRINT_NUMBER, s.START_DATE NULLS LAST, s.ID_SPRINT
+            """;
+
+    private static final String GET_SPRINT_BY_ID_SQL = """
+            SELECT * FROM (
+                SELECT s.ID_SPRINT,
+                       s.ID_PROJECT,
+                       COALESCE(
+                           CASE
+                               WHEN REGEXP_LIKE(s.TITLE, 'Sprint\\s*#\\s*[0-9]+', 'i')
+                                   THEN TO_NUMBER(REGEXP_SUBSTR(s.TITLE, 'Sprint\\s*#\\s*([0-9]+)', 1, 1, NULL, 1))
+                               ELSE NULL
+                           END,
+                           ROW_NUMBER() OVER (PARTITION BY s.ID_PROJECT ORDER BY s.START_DATE NULLS LAST, s.ID_SPRINT)
+                       ) AS SPRINT_NUMBER,
+                       s.TITLE,
+                       s.GOAL,
+                       TO_CHAR(s.START_DATE, 'YYYY-MM-DD') AS START_DATE_TEXT,
+                       TO_CHAR(s.END_DATE, 'YYYY-MM-DD') AS END_DATE_TEXT
+                FROM SPRINT s
+                WHERE s.ID_SPRINT = ?
+            )
+            """;
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public SprintController(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @GetMapping
+    public List<SprintOptionDTO> listSprints(@RequestParam(required = false) Integer projectId) {
+        int resolvedProjectId = projectId != null ? projectId : resolveDefaultProjectId();
+
+        return jdbcTemplate.query(
+                LIST_SPRINTS_SQL,
+                (rs, rowNum) -> new SprintOptionDTO(
+                        rs.getInt("ID_SPRINT"),
+                        rs.getInt("ID_PROJECT"),
+                        rs.getInt("SPRINT_NUMBER"),
+                        rs.getString("TITLE"),
+                        rs.getString("GOAL"),
+                        rs.getString("START_DATE_TEXT"),
+                        rs.getString("END_DATE_TEXT")
+                ),
+                resolvedProjectId
+        );
+    }
+
+    @PostMapping
+    @Transactional
+    public ResponseEntity<SprintOptionDTO> createSprint(@RequestBody SprintCreateRequest request) {
+        if (request == null) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+
+        if (request.sprintNumber == null || request.sprintNumber <= 0) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+
+        int resolvedProjectId = request.projectId != null ? request.projectId : resolveDefaultProjectId();
+
+        Timestamp startDate = parseDateOrNull(request.startDate);
+        Timestamp endDate = parseDateOrNull(request.endDate);
+        if (!isValidDateRange(startDate, endDate)) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+
+        Integer nextId = jdbcTemplate.queryForObject("SELECT NVL(MAX(ID_SPRINT), 0) + 1 FROM SPRINT", Integer.class);
+        if (nextId == null) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+
+        String title = "Sprint #" + request.sprintNumber;
+
+        jdbcTemplate.update(
+                "INSERT INTO SPRINT (ID_SPRINT, ID_PROJECT, TITLE, GOAL, START_DATE, END_DATE) VALUES (?, ?, ?, ?, ?, ?)",
+                nextId,
+                resolvedProjectId,
+            title,
+                normalizeTextOrNull(request.goal),
+                startDate,
+                endDate
+        );
+
+        SprintOptionDTO created = findSprintById(nextId);
+        if (created == null) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @PutMapping("/{sprintId}")
+    @Transactional
+    public ResponseEntity<SprintOptionDTO> updateSprint(
+            @PathVariable int sprintId,
+            @RequestBody SprintUpdateRequest request
+    ) {
+        if (request == null) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+
+        List<Map<String, Object>> existingRows = jdbcTemplate.queryForList(
+                "SELECT ID_PROJECT, TITLE, GOAL, START_DATE, END_DATE FROM SPRINT WHERE ID_SPRINT = ?",
+                sprintId
+        );
+
+        if (existingRows.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        Map<String, Object> existing = existingRows.get(0);
+        int existingProjectId = ((Number) existing.get("ID_PROJECT")).intValue();
+
+        if (request.projectId != null && request.projectId != existingProjectId) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+
+        String resolvedTitle = existing.get("TITLE") != null ? existing.get("TITLE").toString() : null;
+        if (request.sprintNumber != null) {
+            if (request.sprintNumber <= 0) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+            }
+            resolvedTitle = "Sprint #" + request.sprintNumber;
+        }
+
+        if (resolvedTitle == null || resolvedTitle.isBlank()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+
+        String resolvedGoal;
+        if (request.goal != null) {
+            resolvedGoal = normalizeTextOrNull(request.goal);
+        } else {
+            resolvedGoal = existing.get("GOAL") != null ? existing.get("GOAL").toString() : null;
+        }
+
+        Timestamp resolvedStart;
+        if (request.startDate != null) {
+            resolvedStart = parseDateOrNull(request.startDate);
+        } else {
+            resolvedStart = (Timestamp) existing.get("START_DATE");
+        }
+
+        Timestamp resolvedEnd;
+        if (request.endDate != null) {
+            resolvedEnd = parseDateOrNull(request.endDate);
+        } else {
+            resolvedEnd = (Timestamp) existing.get("END_DATE");
+        }
+
+        if (!isValidDateRange(resolvedStart, resolvedEnd)) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+
+        jdbcTemplate.update(
+                "UPDATE SPRINT SET TITLE = ?, GOAL = ?, START_DATE = ?, END_DATE = ? WHERE ID_SPRINT = ?",
+                resolvedTitle,
+                resolvedGoal,
+                resolvedStart,
+                resolvedEnd,
+                sprintId
+        );
+
+        SprintOptionDTO updated = findSprintById(sprintId);
+        if (updated == null) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/{sprintId}")
+    @Transactional
+    public ResponseEntity<Void> deleteSprint(@PathVariable int sprintId) {
+        List<Map<String, Object>> existingRows = jdbcTemplate.queryForList(
+                "SELECT ID_SPRINT FROM SPRINT WHERE ID_SPRINT = ?",
+                sprintId
+        );
+
+        if (existingRows.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        // Clear sprint assignment from tasks first to satisfy FK constraints.
+        jdbcTemplate.update(
+            "UPDATE TASK SET ID_SPRINT = NULL WHERE ID_SPRINT = ?",
+            sprintId
+        );
+
+        jdbcTemplate.update(
+                "DELETE FROM SPRINT WHERE ID_SPRINT = ?",
+                sprintId
+        );
+
+        return ResponseEntity.noContent().build();
+    }
+
+    private SprintOptionDTO findSprintById(int sprintId) {
+        List<SprintOptionDTO> results = jdbcTemplate.query(
+                GET_SPRINT_BY_ID_SQL,
+                (rs, rowNum) -> new SprintOptionDTO(
+                        rs.getInt("ID_SPRINT"),
+                        rs.getInt("ID_PROJECT"),
+                        rs.getInt("SPRINT_NUMBER"),
+                        rs.getString("TITLE"),
+                        rs.getString("GOAL"),
+                        rs.getString("START_DATE_TEXT"),
+                        rs.getString("END_DATE_TEXT")
+                ),
+                sprintId
+        );
+
+        return results.isEmpty() ? null : results.get(0);
+    }
+
+    private int resolveDefaultProjectId() {
+        Integer defaultProject = jdbcTemplate.queryForObject("SELECT MIN(ID_PROJECT) FROM PROJECT", Integer.class);
+        if (defaultProject != null) {
+            return defaultProject;
+        }
+
+        Integer fallbackProject = jdbcTemplate.queryForObject("SELECT MIN(ID_PROJECT) FROM SPRINT", Integer.class);
+        return fallbackProject != null ? fallbackProject : 1;
+    }
+
+    private Timestamp parseDateOrNull(String date) {
+        if (date == null || date.isBlank()) {
+            return null;
+        }
+        return Timestamp.valueOf(LocalDate.parse(date).atStartOfDay());
+    }
+
+    private boolean isValidDateRange(Timestamp start, Timestamp end) {
+        if (start == null || end == null) {
+            return true;
+        }
+        return start.before(end) || start.equals(end);
+    }
+
+    private String normalizeTextOrNull(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value;
+    }
+
+    public static class SprintCreateRequest {
+        public Integer projectId;
+        public Integer sprintNumber;
+        public String goal;
+        public String startDate;
+        public String endDate;
+    }
+
+    public static class SprintUpdateRequest {
+        public Integer projectId;
+        public Integer sprintNumber;
+        public String goal;
+        public String startDate;
+        public String endDate;
+    }
+}

--- a/forgetask/src/main/java/com/cloudforge/api/forgetask/controller/TaskController.java
+++ b/forgetask/src/main/java/com/cloudforge/api/forgetask/controller/TaskController.java
@@ -36,6 +36,7 @@ public class TaskController {
             SELECT t.ID_TASK,
                    t.ID_USER,
                                      t.ID_PROJECT,
+               t.ID_SPRINT,
                    t.TITLE,
                    t.DESCRIPTION,
                    t.START_TIME,
@@ -80,6 +81,7 @@ public class TaskController {
                 rs.getInt("ID_TASK"),
                 rs.getObject("ID_USER"),
                 rs.getObject("ID_PROJECT"),
+            rs.getObject("ID_SPRINT"),
                 rs.getString("TITLE"),
                 rs.getString("DESCRIPTION"),
                 rs.getObject("START_TIME"),
@@ -129,6 +131,10 @@ public class TaskController {
 
         int idUser = assignee.userId();
         int idProject = assignee.projectId();
+        Integer idSprint = resolveSprintIdStrict(task.getSprintId(), idProject);
+        if (task.getSprintId() != null && idSprint == null) {
+            return ResponseEntity.badRequest().build();
+        }
         String title = normalizeText(task.getTitle(), "Untitled task");
         String description = normalizeTextOrNull(task.getDescription());
         Timestamp startTime = parseDateOrNull(task.getStartDate());
@@ -144,10 +150,11 @@ public class TaskController {
         String priority = normalizePriority(task.getPriority(), "medium");
 
         jdbcTemplate.update(
-                "INSERT INTO TASK (ID_TASK, ID_USER, ID_PROJECT, TITLE, DESCRIPTION, START_TIME, END_TIME, ESTIMATED_TIME, REAL_TIME) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO TASK (ID_TASK, ID_USER, ID_PROJECT, ID_SPRINT, TITLE, DESCRIPTION, START_TIME, END_TIME, ESTIMATED_TIME, REAL_TIME) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 nextId,
                 idUser,
                 idProject,
+            idSprint,
                 title,
                 description,
                 startTime,
@@ -179,6 +186,16 @@ public class TaskController {
         ResolvedAssignee assignee = resolveAssignee(task.getAssignedTo(), existingTask.idProject(), existingTask.idUser());
         int idUser = assignee.userId();
         int idProject = assignee.projectId();
+        Integer requestedSprintId = task.getSprintId();
+        Integer resolvedSprintId;
+        if (requestedSprintId == null) {
+            resolvedSprintId = existingTask.idSprint();
+        } else {
+            resolvedSprintId = resolveSprintIdStrict(requestedSprintId, idProject);
+            if (resolvedSprintId == null) {
+                return ResponseEntity.badRequest().build();
+            }
+        }
         String title = normalizeText(task.getTitle(), existingTask.title());
         String description = normalizeText(task.getDescription(), existingTask.description());
         Timestamp startTime = parseDateOrFallback(task.getStartDate(), existingTask.startTime());
@@ -194,9 +211,10 @@ public class TaskController {
         String priority = normalizePriority(task.getPriority(), existingTask.priority());
 
         jdbcTemplate.update(
-            "UPDATE TASK SET ID_USER = ?, ID_PROJECT = ?, TITLE = ?, DESCRIPTION = ?, START_TIME = ?, END_TIME = ?, ESTIMATED_TIME = ?, REAL_TIME = ? WHERE ID_TASK = ?",
+            "UPDATE TASK SET ID_USER = ?, ID_PROJECT = ?, ID_SPRINT = ?, TITLE = ?, DESCRIPTION = ?, START_TIME = ?, END_TIME = ?, ESTIMATED_TIME = ?, REAL_TIME = ? WHERE ID_TASK = ?",
             idUser,
             idProject,
+            resolvedSprintId,
             title,
             description,
             startTime,
@@ -297,6 +315,7 @@ public class TaskController {
                 SELECT t.ID_TASK,
                        t.ID_USER,
                        t.ID_PROJECT,
+                       t.ID_SPRINT,
                        t.TITLE,
                        t.DESCRIPTION,
                        t.START_TIME,
@@ -331,6 +350,7 @@ public class TaskController {
                         rs.getInt("ID_TASK"),
                         rs.getObject("ID_USER"),
                     rs.getObject("ID_PROJECT"),
+                    rs.getObject("ID_SPRINT"),
                         rs.getString("TITLE"),
                         rs.getString("DESCRIPTION"),
                         rs.getObject("START_TIME"),
@@ -357,6 +377,7 @@ public class TaskController {
                 """
                 SELECT t.ID_USER,
                        t.ID_PROJECT,
+                       t.ID_SPRINT,
                        t.TITLE,
                        t.DESCRIPTION,
                        t.START_TIME,
@@ -373,9 +394,13 @@ public class TaskController {
                 ) pt ON pt.ID_TASK = t.ID_TASK
                 WHERE t.ID_TASK = ?
                 """,
-                (rs, rowNum) -> new ExistingTaskSnapshot(
+                (rs, rowNum) -> {
+                    Object sprintIdRaw = rs.getObject("ID_SPRINT");
+                    Integer sprintId = sprintIdRaw instanceof Number number ? number.intValue() : null;
+                    return new ExistingTaskSnapshot(
                         rs.getInt("ID_USER"),
                         rs.getInt("ID_PROJECT"),
+                        sprintId,
                         rs.getString("TITLE"),
                         rs.getString("DESCRIPTION"),
                         rs.getTimestamp("START_TIME"),
@@ -383,7 +408,8 @@ public class TaskController {
                         toNullableDouble(rs.getObject("ESTIMATED_TIME")),
                         toNullableDouble(rs.getObject("REAL_TIME")),
                         rs.getString("PRIORITY")
-                ),
+                    );
+                },
                 taskId
         );
 
@@ -497,6 +523,7 @@ public class TaskController {
             int id,
             Object idUser,
             Object idProject,
+            Object idSprint,
             String title,
             String description,
             Object startTime,
@@ -514,6 +541,7 @@ public class TaskController {
     ) {
         TaskDTO task = new TaskDTO();
         task.setId(String.valueOf(id));
+        task.setSprintId(idSprint instanceof Number number ? number.intValue() : null);
 
         String resolvedTitle = (title != null && !title.isBlank()) ? title : description;
         task.setTitle(resolvedTitle != null ? resolvedTitle : "Untitled task");
@@ -531,6 +559,25 @@ public class TaskController {
         task.setAssignedTo(List.of(displayName));
 
         return task;
+    }
+
+    private Integer resolveSprintIdStrict(Integer sprintId, int projectId) {
+        if (sprintId == null) {
+            return null;
+        }
+
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(1) FROM SPRINT WHERE ID_SPRINT = ? AND ID_PROJECT = ?",
+                Integer.class,
+                sprintId,
+                projectId
+        );
+
+        if (count != null && count > 0) {
+            return sprintId;
+        }
+
+        return null;
     }
 
     private String buildDisplayName(String firstName, String lastName, String username, Object idUser) {
@@ -844,6 +891,7 @@ public class TaskController {
     private record ExistingTaskSnapshot(
             int idUser,
             int idProject,
+            Integer idSprint,
             String title,
             String description,
             Timestamp startTime,

--- a/forgetask/src/main/java/com/cloudforge/api/forgetask/dto/SprintOptionDTO.java
+++ b/forgetask/src/main/java/com/cloudforge/api/forgetask/dto/SprintOptionDTO.java
@@ -1,0 +1,80 @@
+package com.cloudforge.api.forgetask.dto;
+
+public class SprintOptionDTO {
+    private int idSprint;
+    private int idProject;
+    private int sprintNumber;
+    private String title;
+    private String goal;
+    private String startDate;
+    private String endDate;
+
+    public SprintOptionDTO() {
+    }
+
+    public SprintOptionDTO(int idSprint, int idProject, int sprintNumber, String title, String goal, String startDate, String endDate) {
+        this.idSprint = idSprint;
+        this.idProject = idProject;
+        this.sprintNumber = sprintNumber;
+        this.title = title;
+        this.goal = goal;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    public int getIdSprint() {
+        return idSprint;
+    }
+
+    public void setIdSprint(int idSprint) {
+        this.idSprint = idSprint;
+    }
+
+    public int getIdProject() {
+        return idProject;
+    }
+
+    public void setIdProject(int idProject) {
+        this.idProject = idProject;
+    }
+
+    public int getSprintNumber() {
+        return sprintNumber;
+    }
+
+    public void setSprintNumber(int sprintNumber) {
+        this.sprintNumber = sprintNumber;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getGoal() {
+        return goal;
+    }
+
+    public void setGoal(String goal) {
+        this.goal = goal;
+    }
+
+    public String getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(String startDate) {
+        this.startDate = startDate;
+    }
+
+    public String getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(String endDate) {
+        this.endDate = endDate;
+    }
+}

--- a/forgetask/src/main/java/com/cloudforge/api/forgetask/dto/TaskDTO.java
+++ b/forgetask/src/main/java/com/cloudforge/api/forgetask/dto/TaskDTO.java
@@ -9,6 +9,7 @@ import java.util.List;
  */
 public class TaskDTO {
     private String id;
+    private Integer sprintId;
     private String title;
     private String description;
     private String status; // "backlog", "ready", "in-progress", "review", "done"
@@ -49,6 +50,14 @@ public class TaskDTO {
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    public Integer getSprintId() {
+        return sprintId;
+    }
+
+    public void setSprintId(Integer sprintId) {
+        this.sprintId = sprintId;
     }
 
     public String getTitle() {
@@ -151,6 +160,7 @@ public class TaskDTO {
     public String toString() {
         return "TaskDTO{" +
                 "id='" + id + '\'' +
+                ", sprintId=" + sprintId +
                 ", title='" + title + '\'' +
                 ", description='" + description + '\'' +
                 ", status='" + status + '\'' +


### PR DESCRIPTION
This pull request introduces sprint management functionality to the Kanban board, allowing users to create, edit, and delete sprints, as well as assign tasks to specific sprints. The changes include new UI components for sprint management, updates to dialogs and data flows to support sprint assignment, and integration of sprint data throughout the Kanban app.

**Sprint management and integration:**

* Added a new `AddSprintDialog` component for creating, editing, and deleting sprints, including UI and logic for handling sprint details and communicating with the backend (`sprintService`). This dialog is integrated into the Kanban board header. [[1]](diffhunk://#diff-63953ada7b822d1b542b5b8d59ab1ae0e4ebc31f310414c31a88210ef8e94cbaR1-R247) [[2]](diffhunk://#diff-73e6abdcef793c83620266b949524ffe31ea0655dabd41cc8bf13a473c606bf8L406-R425)
* Updated the Kanban board (`KanbanApp.tsx` and `project-board.tsx`) to fetch, store, and manage sprint options based on the current project, and to propagate sprint data and callbacks to child components. [[1]](diffhunk://#diff-f9f3e0fc291011ab684a796c0caea64b573546eca2b7127674a7edae24b6475dR20-R28) [[2]](diffhunk://#diff-f9f3e0fc291011ab684a796c0caea64b573546eca2b7127674a7edae24b6475dR93-R101) [[3]](diffhunk://#diff-f9f3e0fc291011ab684a796c0caea64b573546eca2b7127674a7edae24b6475dR110-R126) [[4]](diffhunk://#diff-f9f3e0fc291011ab684a796c0caea64b573546eca2b7127674a7edae24b6475dR136-R139) [[5]](diffhunk://#diff-73e6abdcef793c83620266b949524ffe31ea0655dabd41cc8bf13a473c606bf8R223-R226) [[6]](diffhunk://#diff-73e6abdcef793c83620266b949524ffe31ea0655dabd41cc8bf13a473c606bf8R238-R241)

**Task dialog and assignment improvements:**

* Enhanced the `AddTaskDialog` to allow users to assign a sprint to a new task, including a dropdown of available sprints and logic to pass the selected sprint ID when creating a task. [[1]](diffhunk://#diff-4fbd9feeba87b201ab1545c23fbd41fa3e212ff5c2c83d43a2773e9849f4feb4R27-R32) [[2]](diffhunk://#diff-4fbd9feeba87b201ab1545c23fbd41fa3e212ff5c2c83d43a2773e9849f4feb4L40-R42) [[3]](diffhunk://#diff-4fbd9feeba87b201ab1545c23fbd41fa3e212ff5c2c83d43a2773e9849f4feb4R54-R68) [[4]](diffhunk://#diff-4fbd9feeba87b201ab1545c23fbd41fa3e212ff5c2c83d43a2773e9849f4feb4R93-R99) [[5]](diffhunk://#diff-4fbd9feeba87b201ab1545c23fbd41fa3e212ff5c2c83d43a2773e9849f4feb4R121) [[6]](diffhunk://#diff-4fbd9feeba87b201ab1545c23fbd41fa3e212ff5c2c83d43a2773e9849f4feb4R199-R217) [[7]](diffhunk://#diff-73e6abdcef793c83620266b949524ffe31ea0655dabd41cc8bf13a473c606bf8L406-R425)
* Updated the `TaskCard` and Kanban columns to receive and use sprint information, enabling display and interaction with sprint-related data at the task level. [[1]](diffhunk://#diff-73e6abdcef793c83620266b949524ffe31ea0655dabd41cc8bf13a473c606bf8R31-R46) [[2]](diffhunk://#diff-73e6abdcef793c83620266b949524ffe31ea0655dabd41cc8bf13a473c606bf8R59) [[3]](diffhunk://#diff-73e6abdcef793c83620266b949524ffe31ea0655dabd41cc8bf13a473c606bf8R201) [[4]](diffhunk://#diff-73e6abdcef793c83620266b949524ffe31ea0655dabd41cc8bf13a473c606bf8R440) [[5]](diffhunk://#diff-73e6abdcef793c83620266b949524ffe31ea0655dabd41cc8bf13a473c606bf8R456)