### PR TITLE
fix: modify all the scripts to connect with a db

### DIFF
--- a/infrastructure/kubernetes/templates/forgetask.yaml
+++ b/infrastructure/kubernetes/templates/forgetask.yaml
@@ -28,34 +28,55 @@ spec:
     spec:
       containers:
         - name: forgetask
-          image: %DOCKER_REGISTRY%/forgetask:%IMAGE_VERSION%
+          image: "%DOCKER_REGISTRY%/forgetask:%IMAGE_VERSION%"
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
           env:
             - name: TNS_ADMIN
               value: "/app/wallet"
-            - name: SPRING_DATASOURCE_URL
-              value: "jdbc:oracle:thin:@%TODO_PDB_NAME%_tp"
-            - name: SPRING_DATASOURCE_USERNAME
+
+            - name: DB_USER
               valueFrom:
                 secretKeyRef:
-                  name: dbuser
-                  key: db_username
-            - name: SPRING_DATASOURCE_PASSWORD
+                  name: forgetask-app-secrets
+                  key: DB_USER
+
+            - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: dbuser
-                  key: dbpassword
+                  name: forgetask-app-secrets
+                  key: DB_PASSWORD
+
+            - name: TELEGRAM_BOT_ENABLED
+              valueFrom:
+                secretKeyRef:
+                  name: forgetask-app-secrets
+                  key: TELEGRAM_BOT_ENABLED
+
+            - name: TELEGRAM_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: forgetask-app-secrets
+                  key: TELEGRAM_BOT_TOKEN
+
+            - name: TELEGRAM_BOT_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: forgetask-app-secrets
+                  key: TELEGRAM_BOT_NAME
+
           volumeMounts:
             - name: wallet-volume
               mountPath: /app/wallet
               readOnly: true
+
       restartPolicy: Always
       volumes:
         - name: wallet-volume
           secret:
             secretName: db-wallet-secret
+
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname

--- a/infrastructure/scripts/deploy/deploy.sh
+++ b/infrastructure/scripts/deploy/deploy.sh
@@ -48,14 +48,14 @@ if [ -z "$DOCKER_REGISTRY" ]; then
     exit 1
 fi
 
-if [ -z "$TODO_PDB_NAME" ]; then
-    export TODO_PDB_NAME=$(state_get MTDR_DB_NAME)
-    echo -e "${greenColour}[deploy.sh][+]${endColour} TODO_PDB_NAME set."
-fi
-if [ -z "$TODO_PDB_NAME" ]; then
-    echo -e "${redColour}[deploy.sh][x]${endColour} TODO_PDB_NAME env variable needs to be set!"
-    exit 1
-fi
+#if [ -z "$TODO_PDB_NAME" ]; then
+#    export TODO_PDB_NAME=$(state_get MTDR_DB_NAME)
+#    echo -e "${greenColour}[deploy.sh][+]${endColour} TODO_PDB_NAME set."
+#fi
+#if [ -z "$TODO_PDB_NAME" ]; then
+#    echo -e "${redColour}[deploy.sh][x]${endColour} TODO_PDB_NAME env variable needs to be set!"
+#    exit 1
+#fi
 
 if [ -z "$OCI_REGION" ]; then
     echo -e "${yellowColour}[deploy.sh][!]${endColour} OCI_REGION not set. Will get it with state_get"
@@ -97,9 +97,9 @@ deploy_manifest() {
         "$TEMPLATE" > "$OUTPUT"
 
     # Solo el backend necesita el nombre de la PDB de Oracle
-    if [ "$SERVICE_TYPE" = "backend" ]; then
-        sed -i "s|%TODO_PDB_NAME%|${TODO_PDB_NAME}|g" "$OUTPUT"
-    fi
+#    if [ "$SERVICE_TYPE" = "backend" ]; then
+#        sed -i "s|%TODO_PDB_NAME%|${TODO_PDB_NAME}|g" "$OUTPUT"
+#    fi
 
     echo -e "${greenColour}[deploy.sh][+]${endColour} Manifest generated: ${OUTPUT}"
 

--- a/infrastructure/scripts/utils/main-setup.sh
+++ b/infrastructure/scripts/utils/main-setup.sh
@@ -37,7 +37,7 @@ while ! state_done RUN_TYPE; do
     state_set_done PROVISIONING
     state_set_done K8S_PROVISIONING
     state_set RUN_NAME "mtdrworkshop$(state_get RESERVATION_ID)"
-    state_set MTDR_DB_NAME "MTDRDB$(state_get RESERVATION_ID)"
+  #    state_set MTDR_DB_NAME "MTDRDB$(state_get RESERVATION_ID)"
     #state_set_done OKE_LIMIT_CHECK
     #state_set_done ATP_LIMIT_CHECK
   else
@@ -94,7 +94,7 @@ while ! state_done RUN_NAME; do
   # Validate run name.  Must be between 1 and 13 characters, only letters or numbers, starting with letter
   if [[ "$DN" =~ ^[a-zA-Z][a-zA-Z0-9]{0,12}$ ]]; then
     state_set RUN_NAME `echo "$DN" | awk '{print tolower($0)}'`
-    state_set MTDR_DB_NAME "$(state_get RUN_NAME)$(state_get MTDR_KEY)"
+  #    state_set MTDR_DB_NAME "$(state_get RUN_NAME)$(state_get MTDR_KEY)"
   else
     echo -e "${redColour}[main-setup.sh][x]${endColour} Error: Invalid directory name $RN.  The directory name must be between 1 and 13 characters,"
     echo -e "${redColour}[main-setup.sh][x]${endColour} containing only letters or numbers, starting with a letter.  Please restart the workshop with a valid directory name."
@@ -200,6 +200,7 @@ while ! state_done DOCKER_REGISTRY; do
     if echo "$TOKEN" | docker login -u "$(state_get NAMESPACE)/$(state_get USER_NAME)" --password-stdin "$(state_get REGION).ocir.io" &>/dev/null; then
       echo -e "${greenColour}[main-setup.sh][+]${endColour} Docker login completed"
       state_set DOCKER_REGISTRY "$(state_get REGION).ocir.io/$(state_get NAMESPACE)/$(state_get RUN_NAME)/$(state_get MTDR_KEY)"
+      state_set DOCKER_REGISTRY_TOKEN "$TOKEN"
       export OCI_CLI_PROFILE=$(state_get REGION)
       break
     else
@@ -220,38 +221,38 @@ if ! state_get OKE_SETUP; then
 fi
 
 # run db-setup.sh in background
-if ! state_get DB_SETUP; then
-  if ps -ef | grep "$MTDRWORKSHOP_LOCATION/utils/db-setup.sh" | grep -v grep; then
-    echo -e "${blueColour}[main-setup.sh][!]${endColour} $MTDRWORKSHOP_LOCATION/utils/db-setup.sh is already running"
-  else
-    echo -e "${purpleColour}[main-setup.sh][*]${endColour} Executing db-setup.sh in the background"
-    nohup $MTDRWORKSHOP_LOCATION/utils/db-setup.sh &>>$MTDRWORKSHOP_LOG/db-setup.log &
-  fi
-fi
+#if ! state_get DB_SETUP; then
+#  if ps -ef | grep "$MTDRWORKSHOP_LOCATION/utils/db-setup.sh" | grep -v grep; then
+#    echo -e "${blueColour}[main-setup.sh][!]${endColour} $MTDRWORKSHOP_LOCATION/utils/db-setup.sh is already running"
+#  else
+#    echo -e "${purpleColour}[main-setup.sh][*]${endColour} Executing db-setup.sh in the background"
+#    nohup $MTDRWORKSHOP_LOCATION/utils/db-setup.sh &>>$MTDRWORKSHOP_LOG/db-setup.log &
+#  fi
+#fi
 
 # Collect DB password
-if ! state_done DB_PASSWORD; then
-  echo
-  echo -e "${purpleColour}[main-setup.sh][*]${endColour} Database passwords must be 12 to 30 characters and contain at least one uppercase letter,"
-  echo -e "${purpleColour}[main-setup.sh][*]${endColour} one lowercase letter, and one number. The password cannot contain the double quote (\")"
-  echo -e "${purpleColour}[main-setup.sh][*]${endColour} character or the word \"admin\"."
-  echo
-
-  while true; do
-    if test -z "$TEST_DB_PASSWORD"; then
-      read -s -r -p "Enter the password to be used for the MTDR database: " PW
-    else
-      PW="$TEST_DB_PASSWORD"
-    fi
-    if [[ ${#PW} -ge 12 && ${#PW} -le 30 && "$PW" =~ [A-Z] && "$PW" =~ [a-z] && "$PW" =~ [0-9] && "$PW" != *admin* && "$PW" != *'"'* ]]; then
-      echo
-      break
-    else
-      echo -e "${redColour}[main-setup.sh][x]${endColour} Invalid Password, please retry"
-    fi
-  done
-  BASE64_DB_PASSWORD=`echo -n "$PW" | base64`
-fi
+#if ! state_done DB_PASSWORD; then
+#  echo
+#  echo -e "${purpleColour}[main-setup.sh][*]${endColour} Database passwords must be 12 to 30 characters and contain at least one uppercase letter,"
+#  echo -e "${purpleColour}[main-setup.sh][*]${endColour} one lowercase letter, and one number. The password cannot contain the double quote (\")"
+#  echo -e "${purpleColour}[main-setup.sh][*]${endColour} character or the word \"admin\"."
+#  echo
+#
+#  while true; do
+#    if test -z "$TEST_DB_PASSWORD"; then
+#      read -s -r -p "Enter the password to be used for the MTDR database: " PW
+#    else
+#      PW="$TEST_DB_PASSWORD"
+#    fi
+#    if [[ ${#PW} -ge 12 && ${#PW} -le 30 && "$PW" =~ [A-Z] && "$PW" =~ [a-z] && "$PW" =~ [0-9] && "$PW" != *admin* && "$PW" != *'"'* ]]; then
+#      echo
+#      break
+#    else
+#      echo -e "${redColour}[main-setup.sh][x]${endColour} Invalid Password, please retry"
+#    fi
+#  done
+#  BASE64_DB_PASSWORD=`echo -n "$PW" | base64`
+#fi
 
 # create UI username
 if ! state_done UI_USERNAME; then
@@ -299,15 +300,15 @@ fi
 
 
 # Get MTDR_DB OCID
-while ! state_done MTDR_DB_OCID; do
-  MTDR_DB_OCID=`oci db autonomous-database list --compartment-id "$(cat state/COMPARTMENT_OCID)" --query 'join('"' '"',data[?"display-name"=='"'MTDRDB'"'].id)' --raw-output`
-  if [[ "$MTDR_DB_OCID" =~ ocid1.autonomousdatabase* ]]; then
-    state_set MTDR_DB_OCID "$MTDR_DB_OCID"
-  else
-    echo -e "${redColour}[main-setup.sh][x]${endColour} ERROR: Incorrect Order DB OCID: $MTDR_DB_OCID"
-    exit
-  fi
-done
+#while ! state_done MTDR_DB_OCID; do
+#  MTDR_DB_OCID=`oci db autonomous-database list --compartment-id "$(cat state/COMPARTMENT_OCID)" --query 'join('"' '"',data[?"display-name"=='"'MTDRDB'"'].id)' --raw-output`
+#  if [[ "$MTDR_DB_OCID" =~ ocid1.autonomousdatabase* ]]; then
+#    state_set MTDR_DB_OCID "$MTDR_DB_OCID"
+#  else
+#    echo -e "${redColour}[main-setup.sh][x]${endColour} ERROR: Incorrect Order DB OCID: $MTDR_DB_OCID"
+#    exit
+#  fi
+#done
 
 
 # Wait for kubectl Setup
@@ -322,42 +323,97 @@ if ! state_done OKE_NAMESPACE; then
 fi
 
 # Collect DB password and create secret
-while ! state_done DB_PASSWORD; do
-  echo -e "${yellowColour}[main-setup.sh][+]${endColour} collecting DB password and creating secret"
-  while true; do
-    if kubectl create -n mtdrworkshop -f -; then
-      state_set_done DB_PASSWORD
-      break
-    else
-      echo -e "${redColour}[main-setup.sh][x]${endColour} Error: Creating DB Password Secret Failed.  Retrying..."
-      sleep 10
-    fi <<!
-{
-   "apiVersion": "v1",
-   "kind": "Secret",
-   "metadata": {
-      "name": "dbuser"
-   },
-   "data": {
-      "dbpassword": "${BASE64_DB_PASSWORD}"
-   }
-}
-!
-  done
-done
-
+#while ! state_done DB_PASSWORD; do
+#  echo -e "${yellowColour}[main-setup.sh][+]${endColour} collecting DB password and creating secret"
+#  while true; do
+#    if kubectl create -n mtdrworkshop -f -; then
+#      state_set_done DB_PASSWORD
+#      break
+#    else
+#      echo -e "${redColour}[main-setup.sh][x]${endColour} Error: Creating DB Password Secret Failed.  Retrying..."
+#      sleep 10
+#    fi <<!
+#{
+#   "apiVersion": "v1",
+#   "kind": "Secret",
+#   "metadata": {
+#      "name": "dbuser"
+#   },
+#   "data": {
+#      "dbpassword": "${BASE64_DB_PASSWORD}"
+#   }
+#}
+#!
+#  done
+#done
 
 # Set admin password in order database
-while ! state_done MTDR_DB_PASSWORD_SET; do
-  echo -e "${yellowColour}[main-setup.sh][+]${endColour} setting admin password in mtdr_db"
-  # get password from vault secret
-  DB_PASSWORD=`kubectl get secret dbuser -n mtdrworkshop --template={{.data.dbpassword}} | base64 --decode`
-  umask 177
-  echo '{"adminPassword": "'"$DB_PASSWORD"'"}' > temp_params
-  umask 22
-  oci db autonomous-database update --autonomous-database-id "$(state_get MTDR_DB_OCID)" --from-json "file://temp_params" >/dev/null
-  rm temp_params
-  state_set_done MTDR_DB_PASSWORD_SET
+#while ! state_done MTDR_DB_PASSWORD_SET; do
+#  echo -e "${yellowColour}[main-setup.sh][+]${endColour} setting admin password in mtdr_db"
+#  # get password from vault secret
+#  DB_PASSWORD=`kubectl get secret dbuser -n mtdrworkshop --template={{.data.dbpassword}} | base64 --decode`
+#  umask 177
+#  echo '{"adminPassword": "'"$DB_PASSWORD"'"}' > temp_params
+#  umask 22
+#  oci db autonomous-database update --autonomous-database-id "$(state_get MTDR_DB_OCID)" --from-json "file://temp_params" >/dev/null
+#  rm temp_params
+#  state_set_done MTDR_DB_PASSWORD_SET
+#done
+
+# Create DB wallet secret from repository wallet directory
+while ! state_done DB_WALLET_SECRET; do
+  WALLET_DIR="${MTDRWORKSHOP_LOCATION}/forgetask/wallet"
+
+  if [ ! -d "$WALLET_DIR" ]; then
+    echo -e "${redColour}[main-setup.sh][x]${endColour} Wallet not found at $WALLET_DIR. Make sure forgetask/wallet/ exists in the repo."
+    exit 1
+  fi
+
+  if kubectl create secret generic db-wallet-secret \
+    --from-file="$WALLET_DIR" \
+    -n mtdrworkshop 2>/dev/null || \
+     kubectl get secret db-wallet-secret -n mtdrworkshop &>/dev/null; then
+    state_set_done DB_WALLET_SECRET
+    echo -e "${greenColour}[main-setup.sh][+]${endColour} db-wallet-secret ready."
+  else
+    echo -e "${redColour}[main-setup.sh][x]${endColour} Error creating db-wallet-secret. Retrying..."
+    sleep 5
+  fi
+done
+
+# Create application secrets for DB credentials and Telegram configuration
+while ! state_done APP_SECRETS_SET; do
+  if [ -z "$DB_USER_INPUT" ]; then
+    read -r -p "Enter DB username: " DB_USER_INPUT
+    echo
+  fi
+  if [ -z "$DB_PASSWORD_INPUT" ]; then
+    read -s -r -p "Enter DB password: " DB_PASSWORD_INPUT
+    echo
+  fi
+  if [ -z "$TELEGRAM_BOT_TOKEN" ]; then
+    read -r -p "Enter Telegram Bot Token (leave empty to disable): " TELEGRAM_BOT_TOKEN
+    echo
+  fi
+  if [ -z "$TELEGRAM_BOT_NAME" ]; then
+    read -r -p "Enter Telegram Bot Name (leave empty to disable): " TELEGRAM_BOT_NAME
+    echo
+  fi
+
+  if kubectl create secret generic forgetask-app-secrets \
+    --from-literal=DB_USER="$DB_USER_INPUT" \
+    --from-literal=DB_PASSWORD="$DB_PASSWORD_INPUT" \
+    --from-literal=TELEGRAM_BOT_ENABLED="${TELEGRAM_BOT_TOKEN:+true}" \
+    --from-literal=TELEGRAM_BOT_TOKEN="${TELEGRAM_BOT_TOKEN:-}" \
+    --from-literal=TELEGRAM_BOT_NAME="${TELEGRAM_BOT_NAME:-}" \
+    -n mtdrworkshop 2>/dev/null || \
+     kubectl get secret forgetask-app-secrets -n mtdrworkshop &>/dev/null; then
+    state_set_done APP_SECRETS_SET
+    echo -e "${greenColour}[main-setup.sh][+]${endColour} forgetask-app-secrets created."
+  else
+    echo -e "${redColour}[main-setup.sh][x]${endColour} Error creating forgetask-app-secrets. Retrying..."
+    sleep 5
+  fi
 done
 
 
@@ -395,7 +451,8 @@ done
 
 ps -ef | grep "$MTDRWORKSHOP_LOCATION/utils" | grep -v grep
 
-bgs="JAVA_BUILDS OKE_SETUP DB_SETUP PROVISIONING"
+#bgs="JAVA_BUILDS OKE_SETUP DB_SETUP PROVISIONING"
+bgs="JAVA_BUILDS OKE_SETUP PROVISIONING"
 while ! state_done SETUP_VERIFIED; do
   NOT_DONE=0
   bg_not_done=

--- a/infrastructure/scripts/utils/oke-setup.sh
+++ b/infrastructure/scripts/utils/oke-setup.sh
@@ -81,10 +81,26 @@ while ! state_done OKE_NAMESPACE; do
   fi
 done
 
-# Wait for TO DO User (avoid concurrent kubectl)
-while ! state_done TODO_USER; do
-  echo -e "${yellowColour}[oke-setup.sh][+]${endColour} `date`: Waiting for TODO_USER"
-  sleep 2
+while ! state_done OCIR_SECRET; do
+  if kubectl create secret docker-registry ocir-secret \
+    --docker-server="$(state_get REGION).ocir.io" \
+    --docker-username="$(state_get NAMESPACE)/$(state_get USER_NAME)" \
+    --docker-password="$(state_get DOCKER_REGISTRY_TOKEN)" \
+    --docker-email="user@example.com" \
+    -n mtdrworkshop 2>/dev/null || \
+     kubectl get secret ocir-secret -n mtdrworkshop &>/dev/null; then
+    state_set_done OCIR_SECRET
+    echo -e "${greenColour}[oke-setup.sh][+]${endColour} ocir-secret created."
+  else
+    echo -e "${redColour}[oke-setup.sh][x]${endColour} Error creating ocir-secret. Retrying..."
+    sleep 5
+  fi
 done
+
+# Wait for TO DO User (avoid concurrent kubectl)
+#while ! state_done TODO_USER; do
+#  echo -e "${yellowColour}[oke-setup.sh][+]${endColour} `date`: Waiting for TODO_USER"
+#  sleep 2
+#done
 
 state_set_done OKE_SETUP


### PR DESCRIPTION
This pull request refactors the Kubernetes and deployment setup to simplify database and application secret management, and to streamline the initialization scripts. It removes the use of the `TODO_PDB_NAME` and `MTDR_DB_NAME` variables, consolidates database and Telegram credentials into a single Kubernetes secret, and updates the deployment manifest and scripts accordingly. The changes also improve the handling of Docker registry secrets for Kubernetes.

The most important changes are:

**Kubernetes Secret and Manifest Updates:**

* The `forgetask.yaml` deployment manifest now pulls database (`DB_USER`, `DB_PASSWORD`) and Telegram bot credentials from a new `forgetask-app-secrets` Kubernetes secret, replacing the previous use of `SPRING_DATASOURCE_*` variables and the separate `dbuser` secret. The manifest also adds support for Telegram bot configuration via secrets.

**Script Refactoring and Secret Management:**

* The main setup script (`main-setup.sh`) removes all logic related to generating and managing `MTDR_DB_NAME`, `TODO_PDB_NAME`, and the legacy `dbuser` secret. Instead, it now prompts the user for DB and Telegram credentials and creates the `forgetask-app-secrets` and `db-wallet-secret` secrets directly in Kubernetes. [[1]](diffhunk://#diff-a1a6219304eebbc6c863d93c0b7d3e5a213f002bcb66d239b981a05003fe967eL40-R40) [[2]](diffhunk://#diff-a1a6219304eebbc6c863d93c0b7d3e5a213f002bcb66d239b981a05003fe967eL97-R97) [[3]](diffhunk://#diff-a1a6219304eebbc6c863d93c0b7d3e5a213f002bcb66d239b981a05003fe967eL302-R311) [[4]](diffhunk://#diff-a1a6219304eebbc6c863d93c0b7d3e5a213f002bcb66d239b981a05003fe967eL325-R416)
* The script disables the background execution of the database setup and password collection steps, further simplifying the setup process. [[1]](diffhunk://#diff-a1a6219304eebbc6c863d93c0b7d3e5a213f002bcb66d239b981a05003fe967eL223-R255) [[2]](diffhunk://#diff-a1a6219304eebbc6c863d93c0b7d3e5a213f002bcb66d239b981a05003fe967eL398-R455)

**Deployment Script Simplification:**

* All references to `TODO_PDB_NAME` have been commented out in `deploy.sh`, as this variable is no longer needed for backend service deployment. [[1]](diffhunk://#diff-785f925f2674740d6e2ca41fd94a48148622883bdbb06e74fb264dfeff5c665dL51-R58) [[2]](diffhunk://#diff-785f925f2674740d6e2ca41fd94a48148622883bdbb06e74fb264dfeff5c665dL100-R102)

**Docker Registry Secret Handling:**

* The OCIR (Oracle Container Registry) Docker registry secret is now created as `ocir-secret` using the correct credentials and is tracked with a state flag, ensuring it is available before deployment. [[1]](diffhunk://#diff-a1a6219304eebbc6c863d93c0b7d3e5a213f002bcb66d239b981a05003fe967eR203) [[2]](diffhunk://#diff-a487a635d26392436718d59f25e32789cc6dac4a63e9504138d03fbb358298acL84-R105)

These changes modernize and streamline the deployment process, making it easier to manage application secrets and reducing the complexity of the setup scripts.