### PR TITLE
fix: modify the path for root project and ..

### DIFF
--- a/infrastructure/scripts/utils/main-setup.sh
+++ b/infrastructure/scripts/utils/main-setup.sh
@@ -83,8 +83,7 @@ done
 
 #Get Run Name from directory name
 while ! state_done RUN_NAME; do
-  cd $MTDRWORKSHOP_LOCATION
-  cd ../..
+  cd "${MTDRWORKSHOP_LOCATION}/../../.."
   # Validate that a folder was creared
   if test "$PWD" == ~; then
     echo -e "${redColour}[main-setup.sh][x]${endColour} ERROR: The workshop is not installed in a separate folder."
@@ -100,7 +99,7 @@ while ! state_done RUN_NAME; do
     echo -e "${redColour}[main-setup.sh][x]${endColour} containing only letters or numbers, starting with a letter.  Please restart the workshop with a valid directory name."
     exit
   fi
-  cd $MTDRWORKSHOP_LOCATION
+  cd "$MTDRWORKSHOP_LOCATION"
 done
 
 # Get the tenancy OCID
@@ -362,7 +361,7 @@ fi
 
 # Create DB wallet secret from repository wallet directory
 while ! state_done DB_WALLET_SECRET; do
-  WALLET_DIR="${MTDRWORKSHOP_LOCATION}/forgetask/wallet"
+  WALLET_DIR="${MTDRWORKSHOP_LOCATION}/../../forgetask/wallet"
 
   if [ ! -d "$WALLET_DIR" ]; then
     echo -e "${redColour}[main-setup.sh][x]${endColour} Wallet not found at $WALLET_DIR. Make sure forgetask/wallet/ exists in the repo."


### PR DESCRIPTION
This pull request makes adjustments to directory navigation and path handling in the `main-setup.sh` script to ensure correct folder references and improve robustness. The most important changes are:

**Directory navigation and path corrections:**

* Updated the script to move up three directories from `MTDRWORKSHOP_LOCATION` instead of two when determining the run name, ensuring the script operates from the expected location.
* Corrected the use of quotes around `$MTDRWORKSHOP_LOCATION` in `cd` commands for safer path handling, especially with spaces in directory names.
* Changed the `WALLET_DIR` path to move up two directories from `MTDRWORKSHOP_LOCATION` before referencing `forgetask/wallet`, fixing the wallet directory lookup.