### PR TITLE
fix: move sharp dependencie

### DIFF
--- a/forgetask-frontend/Dockerfile
+++ b/forgetask-frontend/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /app
 
 COPY package.json package-lock.json ./
 RUN npm ci
+RUN npm install sharp
 
 # Stage 2: Build
 FROM node:20-alpine AS build
@@ -35,8 +36,6 @@ RUN mkdir .next && chown nextjs:nodejs .next
 # Runtime assets.
 COPY --from=build --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=build --chown=nextjs:nodejs /app/.next/static     ./.next/static
-
-RUN npm install sharp
 
 USER nextjs
 


### PR DESCRIPTION
This pull request updates the Dockerfile for the frontend by moving the installation of the `sharp` package from the final runtime stage to the build stage. This change ensures that `sharp` is installed before the build process, which can help prevent build-time errors related to missing dependencies.

**Dockerfile improvements:**

* Moved `RUN npm install sharp` from the final runtime stage to the build stage, ensuring `sharp` is available during the build process (`forgetask-frontend/Dockerfile`). [[1]](diffhunk://#diff-573cfb2f59a2739b287127e24b96bc4be5d26a64fdd85fa1b90778d8cfcc5351R11) [[2]](diffhunk://#diff-573cfb2f59a2739b287127e24b96bc4be5d26a64fdd85fa1b90778d8cfcc5351L39-L40)