### PR TITLE
feat: logic to invite and create a developer user ready

### DIFF
--- a/forgetask/src/main/java/com/cloudforge/api/forgetask/controller/InviteController.java
+++ b/forgetask/src/main/java/com/cloudforge/api/forgetask/controller/InviteController.java
@@ -1,0 +1,38 @@
+package com.cloudforge.api.forgetask.controller;
+
+import com.cloudforge.api.forgetask.dto.invite.CreateInviteRequestDTO;
+import com.cloudforge.api.forgetask.dto.invite.ValidateInviteResponseDTO;
+import com.cloudforge.api.forgetask.service.invite.InviteService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/invites")
+public class InviteController {
+    private final InviteService inviteService;
+
+    public InviteController(InviteService inviteService) {
+        this.inviteService = inviteService;
+    }
+
+    // ── Manager crea la invitación ──────────────────────────────────────────
+    // Protegido con JWT (solo managers autenticados)
+    @PostMapping
+    public ResponseEntity<?> createInvite(@RequestBody CreateInviteRequestDTO request) {
+        String token = inviteService.createInvite(request);
+        return ResponseEntity.ok(Map.of(
+                "inviteToken", token,
+                "inviteLink", "/signup?invite=" + token
+        ));
+    }
+
+    // ── Developer valida el token (ruta PÚBLICA — sin JWT) ──────────────────
+    // El frontend la llama al cargar /signup?invite=TOKEN
+    @GetMapping("/validate/{token}")
+    public ResponseEntity<ValidateInviteResponseDTO> validateInvite(
+            @PathVariable String token) {
+        return ResponseEntity.ok(inviteService.validateToken(token));
+    }
+}

--- a/forgetask/src/main/java/com/cloudforge/api/forgetask/dto/auth/SignupRequestDTO.java
+++ b/forgetask/src/main/java/com/cloudforge/api/forgetask/dto/auth/SignupRequestDTO.java
@@ -6,6 +6,7 @@ public class SignupRequestDTO {
     private String password;
     private String firstName;
     private String lastName;
+    private String inviteToken;
 
     public String getUsername() { return username; }
     public void setUsername(String username) { this.username = username; }
@@ -22,4 +23,6 @@ public class SignupRequestDTO {
     public String getLastName() { return lastName; }
     public void setLastName(String lastName) { this.lastName = lastName; }
 
+    public String getInviteToken()              { return inviteToken; }
+    public void setInviteToken(String token)    { this.inviteToken = token; }
 }

--- a/forgetask/src/main/java/com/cloudforge/api/forgetask/dto/invite/CreateInviteRequestDTO.java
+++ b/forgetask/src/main/java/com/cloudforge/api/forgetask/dto/invite/CreateInviteRequestDTO.java
@@ -1,0 +1,14 @@
+package com.cloudforge.api.forgetask.dto.invite;
+
+public class CreateInviteRequestDTO {
+    private String email;
+    private String role;
+    private Long idProject;
+
+    public String getEmail()            { return email; }
+    public void setEmail(String email)  { this.email = email; }
+    public String getRole()             { return role; }
+    public void setRole(String role)    { this.role = role; }
+    public Long getIdProject()          { return idProject; }
+    public void setIdProject(Long id)   { this.idProject = id; }
+}

--- a/forgetask/src/main/java/com/cloudforge/api/forgetask/dto/invite/ValidateInviteResponseDTO.java
+++ b/forgetask/src/main/java/com/cloudforge/api/forgetask/dto/invite/ValidateInviteResponseDTO.java
@@ -1,0 +1,20 @@
+package com.cloudforge.api.forgetask.dto.invite;
+
+public class ValidateInviteResponseDTO {
+    private String email;
+    private String role;
+    private Long idProject;
+    private boolean valid;
+
+    public ValidateInviteResponseDTO(String email, String role, Long idProject, boolean valid) {
+        this.email = email;
+        this.role = role;
+        this.idProject = idProject;
+        this.valid = valid;
+    }
+
+    public String getEmail()        { return email; }
+    public String getRole()         { return role; }
+    public Long getIdProject()      { return idProject; }
+    public boolean isValid()        { return valid; }
+}

--- a/forgetask/src/main/java/com/cloudforge/api/forgetask/model/ProjectInvite.java
+++ b/forgetask/src/main/java/com/cloudforge/api/forgetask/model/ProjectInvite.java
@@ -1,0 +1,59 @@
+package com.cloudforge.api.forgetask.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "PROJECT_INVITE", schema = "APP_USER")
+public class ProjectInvite {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "invite_seq")
+    @SequenceGenerator(name = "invite_seq", sequenceName = "APP_USER.SEQ_PROJECT_INVITE", allocationSize = 1)
+    @Column(name = "ID_INVITE")
+    private Long idInvite;
+
+    @Column(name = "ID_PROJECT", nullable = false)
+    private Long idProject;
+
+    @Column(name = "EMAIL", nullable = false, length = 100)
+    private String email;
+
+    @Column(name = "ROLE", nullable = false, length = 20)
+    private String role;
+
+    @Column(name = "INVITE_TOKEN", nullable = false, unique = true, length = 255)
+    private String inviteToken;
+
+    @Column(name = "CREATED_AT")
+    private LocalDateTime createdAt;
+
+    @Column(name = "EXPIRES_AT")
+    private LocalDateTime expiresAt;
+
+    @Column(name = "STATUS", length = 20)
+    private String status = "PENDING";
+
+    public Long getIdInvite()                       { return idInvite; }
+    public void setIdInvite(Long id)                { this.idInvite = id; }
+    
+    public Long getIdProject()                      { return idProject; }
+    public void setIdProject(Long idProject)        { this.idProject = idProject; }
+    
+    public String getEmail()                        { return email; }
+    public void setEmail(String email)              { this.email = email; }
+    
+    public String getRole()                         { return role; }
+    public void setRole(String role)                { this.role = role; }
+    
+    public String getInviteToken()                  { return inviteToken; }
+    public void setInviteToken(String token)        { this.inviteToken = token; }
+    
+    public LocalDateTime getCreatedAt()             { return createdAt; }
+    public void setCreatedAt(LocalDateTime d)       { this.createdAt = d; }
+    
+    public LocalDateTime getExpiresAt()             { return expiresAt; }
+    public void setExpiresAt(LocalDateTime d)       { this.expiresAt = d; }
+    
+    public String getStatus()                       { return status; }
+    public void setStatus(String status)            { this.status = status; }
+}

--- a/forgetask/src/main/java/com/cloudforge/api/forgetask/repository/ProjectInviteRepository.java
+++ b/forgetask/src/main/java/com/cloudforge/api/forgetask/repository/ProjectInviteRepository.java
@@ -1,0 +1,10 @@
+package com.cloudforge.api.forgetask.repository;
+
+import com.cloudforge.api.forgetask.model.ProjectInvite;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface ProjectInviteRepository extends JpaRepository<ProjectInvite, Long> {
+    Optional<ProjectInvite> findByInviteToken(String token);
+    boolean existsByEmailAndIdProjectAndStatus(String email, Long idProject, String status);
+}

--- a/forgetask/src/main/java/com/cloudforge/api/forgetask/service/auth/AuthService.java
+++ b/forgetask/src/main/java/com/cloudforge/api/forgetask/service/auth/AuthService.java
@@ -4,10 +4,12 @@ import com.cloudforge.api.forgetask.dto.auth.LoginRequestDTO;
 import com.cloudforge.api.forgetask.dto.auth.LoginResponseDTO;
 import com.cloudforge.api.forgetask.dto.auth.SignupRequestDTO;
 import com.cloudforge.api.forgetask.model.Project;
+import com.cloudforge.api.forgetask.model.ProjectInvite;
 import com.cloudforge.api.forgetask.model.UserRole;
 import com.cloudforge.api.forgetask.model.UserRoleId;
 import com.cloudforge.api.forgetask.repository.ProjectRepository;
 import com.cloudforge.api.forgetask.repository.UserRoleRepository;
+import com.cloudforge.api.forgetask.service.invite.InviteService;
 import org.springframework.transaction.annotation.Transactional;
 import com.cloudforge.api.forgetask.model.UserAccount;
 import com.cloudforge.api.forgetask.repository.UserAccountRepository;
@@ -29,17 +31,20 @@ public class AuthService {
     private final UserAccountRepository userRepo;
     private final ProjectRepository projectRepository;
     private final UserRoleRepository userRoleRepository;
+    private final InviteService inviteService;
     private final PasswordEncoder       passwordEncoder;
     private final JwtUtil               jwtUtil;
 
     public AuthService(UserAccountRepository userRepo,
                        ProjectRepository projectRepository,
                        UserRoleRepository userRoleRepository,
+                       InviteService inviteService,
                        PasswordEncoder passwordEncoder,
                        JwtUtil jwtUtil) {
         this.userRepo        = userRepo;
         this.projectRepository = projectRepository;
         this.userRoleRepository = userRoleRepository;
+        this.inviteService = inviteService;
         this.passwordEncoder = passwordEncoder;
         this.jwtUtil         = jwtUtil;
     }
@@ -103,26 +108,48 @@ public class AuthService {
             throw new RuntimeException("El nombre de usuario ya está en uso.");
         }
 
-        // 2. Crear el Proyecto temporal
-        Project project = new Project();
-        project.setTitle("Proyecto temporal");
-        Project savedProject = projectRepository.save(project);
-
-        // 3. Crear el UserAccount
+        // 2. Preparar UserAccount
         UserAccount user = new UserAccount();
-        user.setIdProject(savedProject.getIdProject());
         user.setUsername(request.getUsername());
         user.setEmail(request.getEmail());
         user.setPassword(passwordEncoder.encode(request.getPassword()));
         user.setFirstName(request.getFirstName());
         user.setLastName(request.getLastName());
-        UserAccount savedUser = userRepo.save(user);
 
-        // 4. Asignar rol MANAGER al nuevo usuario
-        UserRoleId roleId = new UserRoleId(savedUser.getIdUser(), "manager");
+        UserAccount savedUser;
         UserRole role = new UserRole();
-        role.setId(roleId);
-        userRoleRepository.save(role);
+        UserRoleId roleId = new UserRoleId();
+
+        if (request.getInviteToken() != null && !request.getInviteToken().isBlank()) {
+            // Flujo Developer: consume el token y asigna proyecto/rol del invite
+            ProjectInvite invite = inviteService.consumeInvite(request.getInviteToken());
+
+            if (!invite.getEmail().equalsIgnoreCase(request.getEmail())) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "El correo no coincide con la invitación.");
+            }
+
+            user.setIdProject(invite.getIdProject());
+            savedUser = userRepo.save(user);
+
+            roleId.setIdUser(savedUser.getIdUser());
+            roleId.setRole(invite.getRole());
+            role.setId(roleId);
+            userRoleRepository.save(role);
+        } else {
+            // Flujo Manager: crear proyecto temporal y asignar rol manager
+            Project project = new Project();
+            project.setTitle("Proyecto temporal");
+            Project savedProject = projectRepository.save(project);
+
+            user.setIdProject(savedProject.getIdProject());
+            savedUser = userRepo.save(user);
+
+            roleId.setIdUser(savedUser.getIdUser());
+            roleId.setRole("manager");
+            role.setId(roleId);
+            userRoleRepository.save(role);
+        }
 
         // 5. Auto-login: devolver JWT igual que en /login
         return login(new LoginRequestDTO(request.getEmail(), request.getPassword()));

--- a/forgetask/src/main/java/com/cloudforge/api/forgetask/service/invite/InviteService.java
+++ b/forgetask/src/main/java/com/cloudforge/api/forgetask/service/invite/InviteService.java
@@ -1,0 +1,96 @@
+package com.cloudforge.api.forgetask.service.invite;
+
+import com.cloudforge.api.forgetask.dto.invite.CreateInviteRequestDTO;
+import com.cloudforge.api.forgetask.dto.invite.ValidateInviteResponseDTO;
+import com.cloudforge.api.forgetask.model.ProjectInvite;
+import com.cloudforge.api.forgetask.repository.ProjectInviteRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+public class InviteService {
+    private final ProjectInviteRepository inviteRepo;
+
+    public InviteService(ProjectInviteRepository inviteRepo) {
+        this.inviteRepo = inviteRepo;
+    }
+
+    /**
+     * El Manager crea una invitación. Devuelve el token generado
+     * para que el frontend construya el link de invitación.
+     */
+    public String createInvite(CreateInviteRequestDTO request) {
+        // Validar que no exista ya una invitación PENDING para ese email en ese proyecto
+        if (inviteRepo.existsByEmailAndIdProjectAndStatus(
+                request.getEmail(), request.getIdProject(), "PENDING")) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Ya existe una invitación pendiente para ese correo en este proyecto.");
+        }
+
+        String token = UUID.randomUUID().toString();
+
+        ProjectInvite invite = new ProjectInvite();
+        invite.setIdProject(request.getIdProject());
+        invite.setEmail(request.getEmail());
+        invite.setRole(request.getRole());
+        invite.setInviteToken(token);
+        invite.setCreatedAt(LocalDateTime.now());
+        invite.setExpiresAt(LocalDateTime.now().plusHours(48)); // expira en 48h
+        invite.setStatus("PENDING");
+
+        inviteRepo.save(invite);
+        return token;
+    }
+
+    /**
+     * Valida un token de invitación antes del signup.
+     * El frontend usa esto para pre-llenar el email en el formulario.
+     */
+    public ValidateInviteResponseDTO validateToken(String token) {
+        ProjectInvite invite = inviteRepo.findByInviteToken(token)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "Invitación no encontrada o inválida."));
+
+        if (!"PENDING".equals(invite.getStatus())) {
+            throw new ResponseStatusException(HttpStatus.GONE,
+                    "Esta invitación ya fue usada o expiró.");
+        }
+
+        if (LocalDateTime.now().isAfter(invite.getExpiresAt())) {
+            invite.setStatus("EXPIRED");
+            inviteRepo.save(invite);
+            throw new ResponseStatusException(HttpStatus.GONE,
+                    "Esta invitación ha expirado.");
+        }
+
+        return new ValidateInviteResponseDTO(
+                invite.getEmail(),
+                invite.getRole(),
+                invite.getIdProject(),
+                true
+        );
+    }
+
+    /**
+     * Consumir la invitación luego del signup exitoso.
+     * Llamado desde AuthService.signup() cuando llega un inviteToken.
+     */
+    public ProjectInvite consumeInvite(String token) {
+        ProjectInvite invite = inviteRepo.findByInviteToken(token)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "Token de invitación inválido."));
+
+        if (!"PENDING".equals(invite.getStatus())) {
+            throw new ResponseStatusException(HttpStatus.GONE,
+                    "Esta invitación ya fue usada o expiró.");
+        }
+
+        invite.setStatus("ACCEPTED");
+        inviteRepo.save(invite);
+        return invite;
+    }
+}


### PR DESCRIPTION
This pull request introduces a full invitation system for adding developers to projects via invite tokens. It adds new APIs and data models to support invite creation, validation, and consumption, and updates the signup flow to allow users to register using an invite token. The changes are grouped below by theme.

**Invitation System Implementation**

* Added the `ProjectInvite` entity to model invitations, including fields for project, email, role, token, status, and expiration. (`ProjectInvite.java`)
* Created `ProjectInviteRepository` with methods to find invites by token and check for existing pending invites. (`ProjectInviteRepository.java`)
* Implemented `InviteService` to handle invite creation, validation (for pre-filling signup forms), and consumption (marking invites as accepted after signup). (`InviteService.java`)

**API and DTO Additions**

* Introduced `InviteController` with endpoints to create invites (for managers) and validate tokens (for developers, public). (`InviteController.java`)
* Added DTOs: `CreateInviteRequestDTO` for invite creation requests and `ValidateInviteResponseDTO` for validating invite tokens. [[1]](diffhunk://#diff-dd30891ca318bfb05ee9ef1f7671a8b16e17429b3b09b15943415099ac81c9aeR1-R14) [[2]](diffhunk://#diff-679267f9a8e81f8e141fff728ea78aec4c6556b4e7ede69462b668ff10496ea2R1-R20)

**Signup Flow Enhancements**

* Updated `SignupRequestDTO` to include an `inviteToken` field, with getters/setters. (`SignupRequestDTO.java`) [[1]](diffhunk://#diff-4c7d9d88d4d54cbea5f55c729a8216d59462c5167985906e9c0c21ac11306d8cR9) [[2]](diffhunk://#diff-4c7d9d88d4d54cbea5f55c729a8216d59462c5167985906e9c0c21ac11306d8cR26-R27)
* Modified `AuthService.signup()` to support two flows:
  - If an invite token is provided, validates and consumes the invite, assigns the user to the invited project and role.
  - If no invite token, creates a new temporary project and assigns the "manager" role as before. (`AuthService.java`) [[1]](diffhunk://#diff-91955a1cb87da3b4771502cbad6e7b71f04ac2063494b141dff1251b8ca481c6R7-R12) [[2]](diffhunk://#diff-91955a1cb87da3b4771502cbad6e7b71f04ac2063494b141dff1251b8ca481c6R34-R47) [[3]](diffhunk://#diff-91955a1cb87da3b4771502cbad6e7b71f04ac2063494b141dff1251b8ca481c6L106-R152)