### PR TITLE
hotfix: put 2 endpoints in generate report AI

### DIFF
--- a/forgetask-frontend/app/components/kanban/project-board.tsx
+++ b/forgetask-frontend/app/components/kanban/project-board.tsx
@@ -30,10 +30,10 @@ import { AddSprintDialog } from './add-sprint-dialog'
 import { TaskDetailsDialog } from './task-details-dialog'
 import { MembersDialog } from './members-dialog'
 import { ProjectHeader } from './project-header'
-import { Button } from '../ui/button'
 import { useTaskStore } from '@/app/store/taskStore'
 import type { TaskAssigneeOption } from '@/app/types/task'
 import type { SprintOption } from '@/app/types/sprint'
+import reportService from '@/app/services/reportService'
 
 interface ColumnProps {
   title: string
@@ -334,30 +334,22 @@ export function ProjectBoard({
   /**
    * Generar reporte de proyecto
    */
-  const handleGenerateReport = () => {
-    const totalTasks = tasks.length
-    const completedTasks = doneTasks.length
-    const inProgressCount = inProgressTasks.length
-    const totalEstimatedHours = tasks.reduce((sum, task) => sum + (task.estimatedTime || 0), 0)
-    const totalRealHours = tasks.reduce((sum, task) => sum + (task.realTime || 0), 0)
-
-    const report = `Project Board Report\nGenerated: ${new Date().toLocaleString()}\n\n=== Summary ===\nTotal Tasks: ${totalTasks}\nCompleted: ${completedTasks}\nIn Progress: ${inProgressCount}\nBacklog: ${backlogTasks.length}\nReady: ${readyTasks.length}\nReview: ${reviewTasks.length}\n\n=== Time Tracking ===\nTotal Estimated Hours: ${totalEstimatedHours}\nTotal Real Hours: ${totalRealHours}\nVariance: ${totalRealHours - totalEstimatedHours} hours\n\n=== Tasks by Status ===\n${tasks
-      .map(
-        (task) =>
-          `- [${task.status.toUpperCase()}] ${task.title} (Priority: ${task.priority || 'none'})`,
-      )
-      .join('\n')}`
-
-    const blob = new Blob([report], { type: 'text/plain' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `project-report-${new Date().toISOString().split('T')[0]}.txt`
-    document.body.appendChild(a)
-    a.click()
-    document.body.removeChild(a)
-    URL.revokeObjectURL(url)
-  }
+  const handleGenerateReport = useCallback(async () => {
+    try {
+      const { blob, filename } = await reportService.generateCurrentSprintPdfReport()
+      const url = URL.createObjectURL(blob)
+      const link = document.createElement('a')
+      link.href = url
+      link.download = filename
+      document.body.appendChild(link)
+      link.click()
+      document.body.removeChild(link)
+      URL.revokeObjectURL(url)
+    } catch (error) {
+      console.error('Error generating PDF report:', error)
+      window.alert(error instanceof Error ? error.message : 'No se pudo generar el reporte PDF.')
+    }
+  }, [])
 
   const handleOpenKpis = useCallback(() => {
     router.push('/kpis')

--- a/forgetask-frontend/app/components/kanban/project-header.tsx
+++ b/forgetask-frontend/app/components/kanban/project-header.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import Image from 'next/image'
 import {
   BarChart3,
-  FileText,
+  Sparkles,
   Users,
   LucideIcon,
 } from 'lucide-react'
@@ -248,8 +248,8 @@ export function ProjectHeader({
               variant="outline"
               className="cursor-pointer"
             >
-              <FileText className="w-4 h-4 mr-2" />
-              Generate Report
+              <Sparkles className="w-4 h-4 mr-2 text-[#f59e0b] drop-shadow-[0_0_7px_rgba(245,158,11,0.85)]" />
+              Generate Report AI
             </Button>
           )}
 

--- a/forgetask-frontend/app/services/reportService.ts
+++ b/forgetask-frontend/app/services/reportService.ts
@@ -1,0 +1,76 @@
+import { fetchWithAuth } from "@/app/services/apiClient";
+import { getAuthData } from "@/app/services/authUtils";
+
+interface CurrentSprintResponse {
+  idSprint: number;
+  idProject: number;
+  sprintNumber: number;
+  title: string;
+  goal?: string;
+  startDate?: string;
+  endDate?: string;
+}
+
+interface GeneratedReport {
+  blob: Blob;
+  filename: string;
+}
+
+function getFilenameFromContentDisposition(headerValue: string | null): string | null {
+  if (!headerValue) {
+    return null;
+  }
+
+  const utf8Match = headerValue.match(/filename\*=UTF-8''([^;]+)/i);
+  if (utf8Match?.[1]) {
+    return decodeURIComponent(utf8Match[1]);
+  }
+
+  const asciiMatch = headerValue.match(/filename="?([^";]+)"?/i);
+  return asciiMatch?.[1] ?? null;
+}
+
+class ReportService {
+  async generateCurrentSprintPdfReport(): Promise<GeneratedReport> {
+    const { projectId } = getAuthData();
+
+    if (!projectId) {
+      throw new Error("No se encontro projectId en la sesion actual.");
+    }
+
+    const currentSprintResponse = await fetchWithAuth(`/sprints/current?projectId=${projectId}`, {
+      method: "GET",
+    });
+
+    if (!currentSprintResponse.ok) {
+      throw new Error(`No se pudo obtener el sprint actual: ${currentSprintResponse.status} ${currentSprintResponse.statusText}`);
+    }
+
+    const currentSprint: CurrentSprintResponse = await currentSprintResponse.json();
+
+    if (!currentSprint?.idSprint) {
+      throw new Error("La API de sprint actual no devolvio idSprint.");
+    }
+
+    const reportResponse = await fetchWithAuth(
+      `/reports/generate/pdf?projectId=${projectId}&sprintId=${currentSprint.idSprint}`,
+      {
+        method: "GET",
+      }
+    );
+
+    if (!reportResponse.ok) {
+      throw new Error(`No se pudo generar el PDF: ${reportResponse.status} ${reportResponse.statusText}`);
+    }
+
+    const blob = await reportResponse.blob();
+    const filename =
+      getFilenameFromContentDisposition(reportResponse.headers.get("content-disposition")) ??
+      `project-report-sprint-${currentSprint.idSprint}.pdf`;
+
+    return { blob, filename };
+  }
+}
+
+const reportService = new ReportService();
+export default reportService;


### PR DESCRIPTION
This pull request updates the project board's report generation feature to use a new backend-powered PDF report, replacing the previous client-side text report. It introduces a new `reportService` for interacting with the backend, enhances error handling, and updates UI elements to reflect the change.

**Report Generation Improvements:**

* Replaced the client-side text report generation in `ProjectBoard` with an asynchronous call to `reportService.generateCurrentSprintPdfReport()`, which fetches a PDF report from the backend and handles file download and errors more robustly.
* Added a new `reportService` in `reportService.ts` that handles fetching the current sprint and generating the PDF report, including parsing the filename from response headers and error handling.

**UI/UX Updates:**

* Changed the report generation button in `ProjectHeader` to use the `Sparkles` icon with a new style and updated the label to "Generate Report AI" to reflect the new AI-powered PDF report. [[1]](diffhunk://#diff-6e04af35c883a2b80e4ecb75737c97a93459d437b3a1dfca588f3839d9bdc4beL7-R7) [[2]](diffhunk://#diff-6e04af35c883a2b80e4ecb75737c97a93459d437b3a1dfca588f3839d9bdc4beL251-R252)

**Codebase Maintenance:**

* Removed the unused import of `Button` from `project-board.tsx` and added the import for the new `reportService`.