### PR TITLE
Feat/infra only 1 load balancer

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -44,7 +44,8 @@ services:
     ports:
       - "3000:3000"
     environment:
-      NEXT_PUBLIC_API_URL: http://localhost:8080
+      NEXT_PUBLIC_API_URL: ""
+      BACKEND_INTERNAL_URL: "http://backend:8080"
     depends_on:
       - backend
     networks:

--- a/forgetask-frontend/Dockerfile
+++ b/forgetask-frontend/Dockerfile
@@ -14,13 +14,13 @@ RUN npm ci
 FROM node:20-alpine AS builder
 WORKDIR /app
 
+ARG NEXT_PUBLIC_USE_PROXY
+ENV NEXT_PUBLIC_USE_PROXY=$NEXT_PUBLIC_USE_PROXY
+
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
 ENV NEXT_TELEMETRY_DISABLED=1
-
-ARG NEXT_PUBLIC_USE_PROXY
-ENV NEXT_PUBLIC_USE_PROXY=$NEXT_PUBLIC_USE_PROXY
 
 RUN npm run build
 
@@ -32,6 +32,7 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
+ENV NEXT_PUBLIC_USE_PROXY=true
 
 RUN addgroup --system --gid 1001 nodejs \
  && adduser --system --uid 1001 nextjs

--- a/forgetask-frontend/Dockerfile
+++ b/forgetask-frontend/Dockerfile
@@ -19,6 +19,9 @@ COPY . .
 
 ENV NEXT_TELEMETRY_DISABLED=1
 
+ARG NEXT_PUBLIC_USE_PROXY
+ENV NEXT_PUBLIC_USE_PROXY=$NEXT_PUBLIC_USE_PROXY
+
 RUN npm run build
 
 # ==========================================

--- a/forgetask-frontend/app/services/apiBaseUrl.ts
+++ b/forgetask-frontend/app/services/apiBaseUrl.ts
@@ -1,28 +1,7 @@
-const DEFAULT_API_URL = "http://localhost:8080";
-
-const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1"]);
-
-function normalizeConfiguredApiUrl(configuredUrl: string): string {
-  const normalized = configuredUrl.trim() || DEFAULT_API_URL;
-
-  if (typeof window === "undefined") {
-    return normalized.replace(/\/$/, "");
-  }
-
-  try {
-    const parsed = new URL(normalized);
-    const currentHost = window.location.hostname;
-
-    if (LOCAL_HOSTS.has(parsed.hostname) && currentHost && !LOCAL_HOSTS.has(currentHost)) {
-      parsed.hostname = currentHost;
-    }
-
-    return parsed.toString().replace(/\/$/, "");
-  } catch {
-    return normalized.replace(/\/$/, "");
-  }
-}
-
 export function getApiBaseUrl(): string {
-  return normalizeConfiguredApiUrl(process.env.NEXT_PUBLIC_API_URL || DEFAULT_API_URL);
+  if (process.env.NEXT_PUBLIC_USE_PROXY === "true") {
+    return "";
+  }
+
+  return process.env.NEXT_PUBLIC_API_URL?.trim().replace(/\/$/, "") || "http://localhost:8080";
 }

--- a/forgetask-frontend/next.config.ts
+++ b/forgetask-frontend/next.config.ts
@@ -3,10 +3,23 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   /* config options here */
   output: "standalone",
+
   poweredByHeader: false,
+
   allowedDevOrigins: ["host.docker.internal"],
+
   turbopack: {
     root: __dirname,
+  },
+
+  async rewrites() {
+    const backendUrl = process.env.BACKEND_INTERNAL_URL || 'http://forgetask-service:8080';
+    return [
+      {
+        source: "/api/:path*",
+        destination: `${backendUrl}/api/:path*`,
+      },
+    ];
   },
 };
 

--- a/forgetask/src/main/java/com/cloudforge/api/forgetask/config/SecurityConfig.java
+++ b/forgetask/src/main/java/com/cloudforge/api/forgetask/config/SecurityConfig.java
@@ -11,6 +11,11 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.http.HttpMethod;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity
@@ -24,27 +29,54 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-            .cors(cors -> cors.configure(http))
+            // 1. Dile a Spring Security que use el bean corsConfigurationSource que definiremos abajo
+            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .csrf(csrf -> csrf.disable())
             .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
-                // Rutas públicas — login, signup, health
                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .requestMatchers(
                     "/api/auth/**",
                     "/health",
-                    "/actuator/**"
+                    "/actuator/**",
+                    "/ws/tasks/**" // Permitir endpoint de websockets
                 ).permitAll()
-                // TODO: implementar auth en telegram y proteger estas rutas:
-                .anyRequest().permitAll() // Por ahora, dejamos todo abierto para desarrollo. Cambiar a authenticated() cuando implementemos auth en telegram.
-                //.anyRequest().authenticated() // Todo lo demás requiere JWT válido
+                .anyRequest().permitAll() // Todo abierto por ahora
             )
             .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
 
-    /** BCrypt para hashear y verificar contraseñas */
+    /** 
+     * Spring Security lo detecta automáticamente y aplica estas reglas
+     * a nivel de filtro, antes de rechazar la petición.
+     */
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        
+        // Agregar la IP pública de Kubernetes / OCI y localhosts
+        configuration.setAllowedOriginPatterns(Arrays.asList(
+            "http://localhost:*",
+            "http://127.0.0.1:*",
+            "http://host.docker.internal:*",
+            "http://160.34.209.215",
+            "http://160.34.209.215:*"
+        ));
+        
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        
+        // Permitir TODO incluyendo tu JWT Authorization
+        configuration.setAllowedHeaders(Arrays.asList("*"));
+        configuration.setExposedHeaders(Arrays.asList("Authorization"));
+        configuration.setAllowCredentials(true);
+        
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();

--- a/forgetask/src/main/java/com/cloudforge/api/forgetask/config/WebConfig.java
+++ b/forgetask/src/main/java/com/cloudforge/api/forgetask/config/WebConfig.java
@@ -12,16 +12,18 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        registry
-                .addMapping("/**")
-            .allowedOriginPatterns(
-                "http://localhost:*",
-                "http://127.0.0.1:*",
-                "http://host.docker.internal:*"
-            )
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-                .allowedHeaders("*");
-    }
+//    @Override
+//    public void addCorsMappings(CorsRegistry registry) {
+//        registry
+//                .addMapping("/**")
+//            .allowedOriginPatterns(
+//                "http://localhost:*",
+//                "http://127.0.0.1:*",
+//                "http://host.docker.internal:*",
+//                "http://160.34.209.215",
+//                "http://160.34.209.215:*"
+//            )
+//                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+//                .allowedHeaders("*");
+//    }
 }

--- a/forgetask/src/main/java/com/cloudforge/api/forgetask/config/WebSocketConfig.java
+++ b/forgetask/src/main/java/com/cloudforge/api/forgetask/config/WebSocketConfig.java
@@ -62,7 +62,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
             .setAllowedOriginPatterns(
                 "http://localhost:*",
                 "http://127.0.0.1:*",
-                "http://host.docker.internal:*"
+                "http://host.docker.internal:*",
+                "http://160.34.209.215",
+                "http://160.34.209.215:*"
             )
             // SockJS es un fallback que proporciona WebSocket emulado si el navegador no lo soporta
             .withSockJS();

--- a/infrastructure/kubernetes/templates/forgetask-frontend.yaml
+++ b/infrastructure/kubernetes/templates/forgetask-frontend.yaml
@@ -36,8 +36,8 @@ spec:
           ports:
             - containerPort: 3000
           env:
-            - name: NEXT_PUBLIC_API_URL
-              value: "http://forgetask-service:8080"
+            - name: NEXT_PUBLIC_USE_PROXY
+              value: "true"
       restartPolicy: Always
       topologySpreadConstraints:
         - maxSkew: 1

--- a/infrastructure/scripts/deploy/local-build.sh
+++ b/infrastructure/scripts/deploy/local-build.sh
@@ -39,7 +39,8 @@ docker build -t "${DOCKER_REGISTRY}/forgetask:${VERSION}" \
 echo -e "${GREEN}[+]${RESET} Backend listo."
 
 echo -e "\n${YELLOW}[+]${RESET} Construyendo frontend... (versión: ${VERSION})"
-docker build -t "${DOCKER_REGISTRY}/forgetask-frontend:${VERSION}" \
+docker build --build-arg NEXT_PUBLIC_USE_PROXY=true \
+             -t "${DOCKER_REGISTRY}/forgetask-frontend:${VERSION}" \
              -t "${DOCKER_REGISTRY}/forgetask-frontend:latest" \
              "${REPO_ROOT}/forgetask-frontend"
 echo -e "${GREEN}[+]${RESET} Frontend listo."


### PR DESCRIPTION
This pull request introduces several important improvements to the frontend-backend integration, focusing on simplifying API routing, enhancing CORS configuration, and making the deployment setup more robust. The main changes include switching the frontend to use a Next.js proxy for API requests, updating environment variable handling, and centralizing CORS policies in the backend.

**Frontend-backend integration and API routing:**

* The frontend now uses a Next.js rewrite/proxy for `/api` requests, controlled by the `NEXT_PUBLIC_USE_PROXY` environment variable. If enabled, API requests are proxied to the backend, simplifying configuration for different environments. (`forgetask-frontend/next.config.ts`, `forgetask-frontend/app/services/apiBaseUrl.ts`, [[1]](diffhunk://#diff-f6bbdd8a9c3669fcfeb68afa915c4c918a5e3d4e59be816a168f7d2941ce90f5R6-R23) [[2]](diffhunk://#diff-aae3424df27cab110a1f5f605ae7218aed8f12b3e27aaa4616ae1145ad8737eeL1-R6)
* The frontend Dockerfile and Kubernetes deployment manifest were updated to set `NEXT_PUBLIC_USE_PROXY=true`, ensuring consistent behavior across local and production deployments. (`forgetask-frontend/Dockerfile`, `infrastructure/kubernetes/templates/forgetask-frontend.yaml`, [[1]](diffhunk://#diff-573cfb2f59a2739b287127e24b96bc4be5d26a64fdd85fa1b90778d8cfcc5351R17-R19) [[2]](diffhunk://#diff-573cfb2f59a2739b287127e24b96bc4be5d26a64fdd85fa1b90778d8cfcc5351R35) [[3]](diffhunk://#diff-320492d82c7f08847cb51a00636b00378d1ba6f116c5f422395f945c4cc2a246L39-R40)
* The local build script now passes `NEXT_PUBLIC_USE_PROXY` as a build argument to the frontend Docker image. (`infrastructure/scripts/deploy/local-build.sh`, [infrastructure/scripts/deploy/local-build.shL42-R43](diffhunk://#diff-63a7a3672efd79d4b2a75ca56117885fca9183307b54d2e99e1c9614df3db6d9L42-R43))

**CORS and backend configuration:**

* The backend (`SecurityConfig.java`) now defines and centralizes CORS policies using a `CorsConfigurationSource` bean, allowing specific origins (including public IPs and localhost variants) and exposing the `Authorization` header. This replaces the previous approach in `WebConfig.java`. (`forgetask/src/main/java/com/cloudforge/api/forgetask/config/SecurityConfig.java`, [[1]](diffhunk://#diff-2a94684487f567814299554026cbde2adca3daf634fc8d3b9287c5b92122ea55R14-R18) [[2]](diffhunk://#diff-2a94684487f567814299554026cbde2adca3daf634fc8d3b9287c5b92122ea55L27-R79)
* The old CORS mapping in `WebConfig.java` is now commented out to avoid conflicts, as CORS is handled in the security configuration. (`forgetask/src/main/java/com/cloudforge/api/forgetask/config/WebConfig.java`, [forgetask/src/main/java/com/cloudforge/api/forgetask/config/WebConfig.javaL15-R28](diffhunk://#diff-d877a8c91dc95a15716a6bd2c106aade7f4a7cc70cb5affd0d7b51b86aea1553L15-R28))
* WebSocket endpoint configuration now also allows connections from the public IP and its port variants. (`forgetask/src/main/java/com/cloudforge/api/forgetask/config/WebSocketConfig.java`, [forgetask/src/main/java/com/cloudforge/api/forgetask/config/WebSocketConfig.javaL65-R67](diffhunk://#diff-620ff1a344199d0fa4bbad1e5a70c8ff7d72f10d9ef3a7dbf9dac97f1d2e35c5L65-R67))

**Other environment and configuration updates:**

* The `docker-compose.dev.yml` file was updated to support the new proxying approach and internal backend URL environment variable.

These changes together make the development and deployment experience more reliable, flexible, and secure, especially when running in different environments (local, Docker, or Kubernetes).