### PR TITLE
fix: move dependencie sharp to json and cache + buildx ready for OCI

### DIFF
--- a/forgetask-frontend/Dockerfile
+++ b/forgetask-frontend/Dockerfile
@@ -42,8 +42,6 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 
-RUN npm install sharp@latest
-
 USER nextjs
 
 EXPOSE 3000

--- a/forgetask-frontend/package-lock.json
+++ b/forgetask-frontend/package-lock.json
@@ -31,6 +31,7 @@
         "react-hook-form": "^7.74.0",
         "recharts": "^3.8.1",
         "shadcn": "^4.5.0",
+        "sharp": "^0.34.5",
         "sockjs-client": "^1.6.1",
         "tailwind-merge": "^3.5.0",
         "tailwind-variants": "^3.2.2",
@@ -1123,7 +1124,6 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -6600,7 +6600,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -11591,7 +11590,6 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -11635,7 +11633,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/forgetask-frontend/package.json
+++ b/forgetask-frontend/package.json
@@ -32,6 +32,7 @@
     "react-hook-form": "^7.74.0",
     "recharts": "^3.8.1",
     "shadcn": "^4.5.0",
+    "sharp": "^0.34.5",
     "sockjs-client": "^1.6.1",
     "tailwind-merge": "^3.5.0",
     "tailwind-variants": "^3.2.2",


### PR DESCRIPTION
This pull request updates the handling of the `sharp` image processing library in the frontend build process. The main change is to move the installation of `sharp` from a manual step in the Dockerfile to being managed as a regular dependency in `package.json`. Additionally, some optional dependency flags have been removed from `package-lock.json`, which may affect how certain dependencies are installed.

**Dependency management changes:**

* Added `sharp@^0.34.5` as a regular dependency in both `package.json` and `package-lock.json`, ensuring it is installed consistently with other dependencies. [[1]](diffhunk://#diff-e33b9d05c75a663527e30940395394d54e2b9a4b2cae6f0206c8dc1cda7c065fR35) [[2]](diffhunk://#diff-153c320ee592717d39ed06db37d0c40935719a721cc7521add3eb6c6ec542ea9R34)
* Removed the manual `RUN npm install sharp@latest` step from the Dockerfile, as `sharp` is now installed via the package manager.

**Package lock and dependency flags:**

* Removed several `optional: true` and `devOptional: true` flags from dependencies in `package-lock.json`, which may change how optional dependencies are treated during install. [[1]](diffhunk://#diff-153c320ee592717d39ed06db37d0c40935719a721cc7521add3eb6c6ec542ea9L1126) [[2]](diffhunk://#diff-153c320ee592717d39ed06db37d0c40935719a721cc7521add3eb6c6ec542ea9L6603) [[3]](diffhunk://#diff-153c320ee592717d39ed06db37d0c40935719a721cc7521add3eb6c6ec542ea9L11594) [[4]](diffhunk://#diff-153c320ee592717d39ed06db37d0c40935719a721cc7521add3eb6c6ec542ea9L11638)