### PR TITLE
Modify and document long polling issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ frontend/build
 .env.development.local
 .env.test.local
 .env.production.local
+
+# Never commit local env files
+.env
 .idea
 
 frontend/package-lock.json

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ TELEGRAM_BOT_TOKEN=
 TELEGRAM_BOT_NAME=
 ```
 
+Nota para despliegues **Blue/Green en OKE**: si usas **long polling** con Telegram, no puedes tener `TELEGRAM_BOT_ENABLED=true` en `ns-blue` y `ns-green` al mismo tiempo usando el mismo token (Telegram responde **409 conflict**). Mantén el bot habilitado solo en el namespace activo.
+
 Puedes usar `.env.example` como referencia:
 
 ```bash

--- a/TELEGRAM_BOT_SETUP.md
+++ b/TELEGRAM_BOT_SETUP.md
@@ -189,6 +189,24 @@ DELETE FROM TASK WHERE ID_TASK = ?
 - Verifica la conexión a Oracle ATP: `curl http://localhost:8080/health`
 - Revisa que la BD tiene datos: `SELECT COUNT(*) FROM TASK;` en SQL*Plus
 
+### Error 409 `TelegramApiErrorResponseException` (Blue/Green en OKE)
+
+Si ves en logs algo como:
+
+- `Caused by: 409: ... TelegramApiErrorResponseException`
+- `Error received from Telegram GetUpdates Request...`
+
+Significa casi siempre que **hay 2 instancias (pods) intentando hacer long polling con el mismo token**.
+
+En Blue/Green (ej. `ns-blue` y `ns-green`) esto ocurre cuando ambos namespaces tienen `TELEGRAM_BOT_ENABLED=true`.
+
+**Fix recomendado:** habilitar el bot solo en el namespace activo.
+
+- Namespace activo: `TELEGRAM_BOT_ENABLED=true`
+- Namespace standby: `TELEGRAM_BOT_ENABLED=false`
+
+En el cutover, invierte los valores.
+
 ## Integración con el Kanban Web
 
 El bot de Telegram y el Kanban web comparten la **misma base de datos**:

--- a/TELEGRAM_IMPLEMENTATION.md
+++ b/TELEGRAM_IMPLEMENTATION.md
@@ -36,9 +36,11 @@ El bot de Telegram está completamente integrado en la aplicación Spring Boot `
 
 ```properties
 TELEGRAM_BOT_ENABLED=true
-TELEGRAM_BOT_TOKEN=7976550635:AAHdO4CNGdyzMq1EV5LeFWur5CQSOKNLN9s
-TELEGRAM_BOT_NAME=oci_deploy_bot
+TELEGRAM_BOT_TOKEN=<TU_TOKEN_DE_BOTFATHER>
+TELEGRAM_BOT_NAME=<tu_bot_username>
 ```
+
+> Nunca guardes tokens reales en el repo. En OCI/OKE usa OCI Vault y/o Kubernetes Secrets.
 
 ### Clases de Configuración
 
@@ -54,25 +56,25 @@ TELEGRAM_BOT_NAME=oci_deploy_bot
 
 ### Secrets en Kubernetes
 
-En `infrastructure/kubernetes/templates/forgetask.yaml`:
+En OKE, las variables se inyectan desde Kubernetes Secrets. En este repo, el despliegue de backend referencia el secreto `forgetask-app-secrets` (por namespace) y lee estas keys:
 
 ```yaml
 env:
   - name: TELEGRAM_BOT_ENABLED
     valueFrom:
       secretKeyRef:
-        name: telegram-secrets
-        key: bot-enabled
+            name: forgetask-app-secrets
+            key: TELEGRAM_BOT_ENABLED
   - name: TELEGRAM_BOT_TOKEN
     valueFrom:
       secretKeyRef:
-        name: telegram-secrets
-        key: bot-token
+            name: forgetask-app-secrets
+            key: TELEGRAM_BOT_TOKEN
   - name: TELEGRAM_BOT_NAME
     valueFrom:
       secretKeyRef:
-        name: telegram-secrets
-        key: bot-name
+            name: forgetask-app-secrets
+            key: TELEGRAM_BOT_NAME
 ```
 
 ---
@@ -444,9 +446,16 @@ docker compose logs -f backend
 
 ### ⚠️ Consideraciones
 
-- **Token en `.env`**: Archivo visible en el repositorio (rotación antes de producción recomendada)
+- **Token en `.env`**: Nunca debe commitearse. Usa `.env.example` como plantilla y crea tu `.env` solo en local.
 - **Long Polling**: Menos seguro que WebHooks, requiere validación adicional en producción
+- **Blue/Green en OKE (ns-blue/ns-green)**: con long polling, **solo puede existir 1 consumidor activo de `getUpdates` por token**. Si ambos namespaces levantan el bot con el mismo token, Telegram responderá **409 (conflict)**.
 - **Permisos de Usuario**: No hay validación de permisos en el bot (TODO)
+
+#### Mitigación recomendada para Blue/Green
+
+- Mantén `TELEGRAM_BOT_ENABLED=true` solo en el namespace activo.
+- En el namespace standby déjalo en `false` para evitar el 409.
+- En el cutover (swap) invierte los valores (habilitar nuevo / deshabilitar anterior).
 
 ### Recomendaciones
 

--- a/forgetask/src/main/java/com/cloudforge/api/forgetask/controller/TelegramBotController.java
+++ b/forgetask/src/main/java/com/cloudforge/api/forgetask/controller/TelegramBotController.java
@@ -9,6 +9,7 @@ import com.cloudforge.api.forgetask.util.ConversationalTaskCreator;
 import com.cloudforge.api.forgetask.util.TaskCreationStep;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import org.telegram.telegrambots.longpolling.BotSession;
@@ -31,16 +32,19 @@ public class TelegramBotController implements SpringLongPollingBot, LongPollingS
 	private final TelegramBotConfig telegramBotConfig;
 	private final ConversationManager conversationManager;
 	private final TelegramReportService telegramReportService;
+	private final String podNamespace;
 
 	public TelegramBotController(TelegramBotConfig telegramBotConfig, TaskController taskController,
 	                             SprintController sprintController, TelegramClient telegramClient,
-	                             ConversationManager conversationManager, TelegramReportService telegramReportService) {
+	                             ConversationManager conversationManager, TelegramReportService telegramReportService,
+	                             @Value("${POD_NAMESPACE:unknown}") String podNamespace) {
 		this.telegramBotConfig = telegramBotConfig;
 		this.taskController = taskController;
 		this.sprintController = sprintController;
 		this.telegramClient = telegramClient;
 		this.conversationManager = conversationManager;
 		this.telegramReportService = telegramReportService;
+		this.podNamespace = podNamespace;
 	}
 
 	@Override
@@ -111,6 +115,10 @@ public class TelegramBotController implements SpringLongPollingBot, LongPollingS
 
 	@AfterBotRegistration
 	public void afterRegistration(BotSession botSession) {
-		logger.info("Telegram bot registered and running state is: {}", botSession.isRunning());
+		logger.info("Telegram bot registered (namespace={}, botName={}) and running state is: {}",
+				podNamespace,
+				telegramBotConfig.getName(),
+				botSession.isRunning());
+		logger.info("If you see Telegram 409 conflicts, ensure only ONE namespace/pod is running long polling for this bot token (common in blue/green).");
 	}
 }


### PR DESCRIPTION
This pull request focuses on improving documentation and code clarity around deploying the Telegram bot in Blue/Green environments (such as OKE), with an emphasis on avoiding issues caused by running multiple bot instances with the same token. It also makes minor improvements to secrets management and logging for better operational transparency.

**Blue/Green deployment and long polling guidance:**

* Added explicit documentation in `README.md`, `TELEGRAM_BOT_SETUP.md`, and `TELEGRAM_IMPLEMENTATION.md` about the 409 conflict error from Telegram when two pods/namespaces attempt long polling with the same bot token. Clear instructions are now provided to enable the bot only in the active namespace and to toggle the setting during cutover. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R39-R40) [[2]](diffhunk://#diff-968cbb27342732b269e5c81f7f8fde406d14e0beebac6645d31643961f0d63dcR192-R209) [[3]](diffhunk://#diff-d75c5195aa0d6743e01f7c2d55870f039193c51d5c6d439061b0be86ce8f676fL447-R459)

**Secrets and configuration improvements:**

* Updated `TELEGRAM_IMPLEMENTATION.md` to clarify that real tokens should never be committed, and recommends using OCI Vault or Kubernetes Secrets for production deployments.
* Updated Kubernetes deployment instructions to use a unified secret (`forgetask-app-secrets`) for all Telegram bot environment variables, improving clarity and security.

**Code enhancements for observability:**

* Modified `TelegramBotController` to inject the pod namespace via the `POD_NAMESPACE` environment variable and include it in the bot registration log message. This helps operators quickly identify which pod/namespace is running the bot and provides a warning about possible 409 conflicts. [[1]](diffhunk://#diff-ac43c6f9175610ab84b0f9827dbb171830be5373a6c04ac56781f72458725df2R12) [[2]](diffhunk://#diff-ac43c6f9175610ab84b0f9827dbb171830be5373a6c04ac56781f72458725df2R35-R47) [[3]](diffhunk://#diff-ac43c6f9175610ab84b0f9827dbb171830be5373a6c04ac56781f72458725df2L114-R122)