### PR TITLE
Core/tests memo

### DIFF
--- a/infrastructure/shell/scripts/report_failed_tests.py
+++ b/infrastructure/shell/scripts/report_failed_tests.py
@@ -20,7 +20,7 @@ def _post_json(url, payload, headers):
     with urllib.request.urlopen(req, timeout=30) as resp:
         return resp.read().decode("utf-8"), resp.getcode()
 
-def create_issue(test_nodeid, error_msg, target_namespace, image_tag):
+def create_issue(test_nodeid, stage_data, target_namespace, image_tag):
     gh_token = os.environ.get("GITHUB_TOKEN")
     owner = os.environ.get("GITHUB_OWNER")
     repo = os.environ.get("GITHUB_REPO")
@@ -36,11 +36,28 @@ def create_issue(test_nodeid, error_msg, target_namespace, image_tag):
         "Content-Type": "application/json",
     }
 
-    title = f"[E2E Fallido] {test_nodeid.split('::')[-1]} en {target_namespace}"
+    test_name = test_nodeid.split('::')[-1]
+    test_file = test_nodeid.split('::')[0]
+    
+    error_msg = stage_data.get("crash", {}).get("message", "Error desconocido")
+    long_repr = str(stage_data.get("longrepr", "No stacktrace available."))
+
+    title = f"[E2E] Fallo en {test_name}"
     body = (
-        f"**Namespace:** {target_namespace}\n"
-        f"**Imagen:** `{image_tag}`\n\n"
-        f"**Error:**\n```python\n{error_msg[:3000]}\n```"
+        f"### Fallo Test E2E: `{test_name}`\n"
+        f"**Archivo:** `{test_file}`\n"
+        f"**Entorno (Namespace):** `{target_namespace}`\n"
+        f"**Imagen Desplegada:** `{image_tag}`\n\n"
+        f"#### Mensaje de Error\n"
+        f"```text\n"
+        f"{error_msg}\n"
+        f"```\n\n"
+        f"<details>\n"
+        f"<summary><strong>Ver Stack Trace (Haz clic para expandir)</strong></summary>\n\n"
+        f"```python\n"
+        f"{long_repr[:60000]}\n"
+        f"```\n\n"
+        f"</details>"
     )
 
     res_body, status = _post_json(
@@ -151,5 +168,7 @@ image_tag = os.environ.get("BUILDRUN_HASH", "latest")
 
 for test in report.get("tests", []):
     if test.get("outcome") in ("failed", "error"):
-        error_msg = test.get("call", {}).get("crash", {}).get("message", "Error desconocido")
-        create_issue(test.get("nodeid"), error_msg, target_namespace, image_tag)
+        stage_data = test.get("call", {})
+        if not stage_data:
+            stage_data = test.get("setup", {})
+        create_issue(test.get("nodeid"), stage_data, target_namespace, image_tag)

--- a/tests/selenium/test_01_create_task.py
+++ b/tests/selenium/test_01_create_task.py
@@ -22,7 +22,7 @@ def test_create_task_is_visible_in_backlog(driver, settings: SeleniumSettings):
         board.create_task(
             title=task_title,
             description=description,
-            status="backlog",
+            status="backlog1",
             priority="medium",
             sprint="3",
             estimated_hours="3",


### PR DESCRIPTION
This pull request updates the failed E2E test reporting script to improve the quality and detail of GitHub issues created for test failures. The main changes focus on enhancing the information included in the issue, making debugging easier, and ensuring the correct test stage data is used. There is also a small change in a Selenium test, likely for testing purposes.

**Enhanced E2E Test Failure Reporting:**

* The `create_issue` function now receives `stage_data` instead of just an error message, allowing it to extract both the error message and a detailed stack trace for inclusion in the GitHub issue.
* The GitHub issue body has been restructured to include the test name, file, namespace, deployed image, error message, and a collapsible stack trace for easier debugging.
* The script now correctly determines which stage data (`call` or `setup`) to use for failed tests, ensuring the most relevant error information is reported.

**Test Change:**

* In the Selenium test `test_create_task_is_visible_in_backlog`, the `status` argument was changed from `"backlog"` to `"backlog1"`, likely to test behavior with a non-standard status.